### PR TITLE
fix logging of writing CSV files

### DIFF
--- a/ms2pip/ms2pipC.py
+++ b/ms2pip/ms2pipC.py
@@ -1175,7 +1175,7 @@ class MS2PIP:
             )
 
         if "csv" in self.out_formats:
-            logger.info("writing CSV %s_predictions.csv...".format(self.output_filename))
+            logger.info("writing CSV %s_predictions.csv...", self.output_filename)
             all_preds.to_csv(
                 "{}_predictions.csv".format(self.output_filename), index=False
             )


### PR DESCRIPTION
The log message when writing the CSV file was broken by 5bb8e17e8a032d8dcb03c7bda042298ffff83f1e.