### PR TITLE
fix average mass in fasta2speclib config

### DIFF
--- a/fasta2speclib/fasta2speclib_config.json
+++ b/fasta2speclib/fasta2speclib_config.json
@@ -7,7 +7,7 @@
     "modifications":[
         {"name":"Glu->pyro-Glu", "unimod_accession":27, "mass_shift":-18.0153, "amino_acid":"E", "n_term":true, "fixed":false},
         {"name":"Gln->pyro-Glu", "unimod_accession":28, "mass_shift":-17.0305, "amino_acid":"Q", "n_term":true, "fixed":false},
-        {"name":"Acetyl", "unimod_accession":1, "mass_shift":42.0367, "amino_acid":null, "n_term":true, "fixed":false},
+        {"name":"Acetyl", "unimod_accession":1, "mass_shift":42.01057, "amino_acid":null, "n_term":true, "fixed":false},
         {"name":"Oxidation", "unimod_accession":35, "mass_shift":15.9994, "amino_acid":"M", "n_term":false, "fixed":false},
         {"name":"Carbamidomethyl", "unimod_accession":4, "mass_shift":57.0513, "amino_acid":"C", "n_term":false, "fixed":true}
     ],


### PR DESCRIPTION
Use mono-isotopic mass instead of average mass in fasta2speclib default configuration