### PR TITLE
Update GitHub actions 

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -49,7 +49,7 @@ jobs:
         twine upload wheelhouse/ms2pip*-manylinux1_x86_64.whl
         twine upload dist/*.tar.gz
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2-preview
       with:
         name: wheels
         path: wheelhouse/ms2pip*-manylinux1_x86_64.whl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,15 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Build ms2pip
+    - name: Build and install ms2pip
       run: |
-        pip install --editable .
+        python setup.py bdist_wheel
+        pip install dist/ms2pip*.whl
     - name: Test with pytest
       run: |
         pytest
+    - uses: actions/upload-artifact@v2-preview
+      with:
+        name: wheels
+        path: dist/ms2pip*.whl
+  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest numpy pandas cython tables
+        pip install wheel flake8 pytest numpy pandas cython tables
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
Use upload-artifact v2-preview action, also add upload-artifact to test workflow. This is a temporary workaround for #54, until upload-artifact v2 is released.