### PR TITLE
macOS support, fixed sdist packaging

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -5,51 +5,96 @@ on:
     types: [created]
 
 jobs:
-  deploy:
+  build-sdist:
+    name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools numpy cython
+      - name: Build sdist
+        run: python setup.py sdist
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist/*.tar.gz
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+  build-linux-wheels:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install twine flake8 numpy pandas cython pytest
-
-    - name: Lint with flake8
+        pip install flake8 numpy pandas cython pytest
+    - name: Check for syntax errors
       run: |
         pip install flake8
         flake8 ./ms2pip ./fasta2speclib --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 ./ms2pip ./fasta2speclib --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-
     - name: Build manylinux wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.2.2-manylinux1_x86_64
+      uses: RalfG/python-wheels-manylinux-build@v0.3.1
       with:
         python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38'
         build-requirements: 'setuptools numpy cython'
-
     - name: Test build
       run: |
-        pip install wheelhouse/ms2pip-*-cp38-cp38-manylinux1_x86_64.whl
+        pip install dist/ms2pip-*-cp38-cp38-manylinux*_x86_64.whl
         pytest
-
-#    - name: Package source distribution
-#      run: |
-#        python setup.py sdist
-
-    - name: Publish to PyPI
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        twine upload wheelhouse/ms2pip*-manylinux1_x86_64.whl
-        twine upload dist/*.tar.gz
-
     - uses: actions/upload-artifact@v2
       with:
-        name: wheels
-        path: wheelhouse/ms2pip*-manylinux1_x86_64.whl
+        name: dist
+        path: dist/ms2pip-*-manylinux1_x86_64.whl
+
+  build-macos-wheels:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 numpy pandas cython pytest
+    - name: Check for syntax errors
+      run: |
+        pip install flake8
+        flake8 ./ms2pip ./fasta2speclib --count --select=E9,F63,F7,F82 --show-source --statistics
+    - name: Build wheels
+      run: |
+        python setup.py bdist_wheel
+    - name: Test build
+      run: |
+        pip install dist/ms2pip-*.whl
+        pytest
+    - uses: actions/upload-artifact@v2
+      with:
+        name: dist
+        path: dist/ms2pip-*-macosx*.whl
+
+  publish-to-pypi:
+    needs: [build-sdist, build-linux-wheels, build-macos-wheels]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -1,9 +1,8 @@
-name: Publish to PyPI
+name: Build and publish to PyPI
 
 on:
   release:
     types: [created]
-  push:
 
 jobs:
   build-sdist:
@@ -87,15 +86,15 @@ jobs:
         name: dist
         path: dist/ms2pip-*-macosx*.whl
 
-#  publish-to-pypi:
-#    needs: [build-sdist, build-linux-wheels, build-macos-wheels]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/download-artifact@v2
-#        with:
-#          name: dist
-#          path: dist
-#      - uses: pypa/gh-action-pypi-publish@master
-#        with:
-#          user: ${{ secrets.PYPI_USERNAME }}
-#          password: ${{ secrets.PYPI_PASSWORD }}
+  publish-to-pypi:
+    needs: [build-sdist, build-linux-wheels, build-macos-wheels]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -70,7 +70,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 numpy pandas cython pytest
+        pip install flake8 setuptools wheel numpy pandas cython pytest
     - name: Check for syntax errors
       run: |
         pip install flake8

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -3,6 +3,7 @@ name: Publish to PyPI
 on:
   release:
     types: [created]
+  push:
 
 jobs:
   build-sdist:
@@ -86,15 +87,15 @@ jobs:
         name: dist
         path: dist/ms2pip-*-macosx*.whl
 
-  publish-to-pypi:
-    needs: [build-sdist, build-linux-wheels, build-macos-wheels]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist
-          path: dist
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}
+#  publish-to-pypi:
+#    needs: [build-sdist, build-linux-wheels, build-macos-wheels]
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/download-artifact@v2
+#        with:
+#          name: dist
+#          path: dist
+#      - uses: pypa/gh-action-pypi-publish@master
+#        with:
+#          user: ${{ secrets.PYPI_USERNAME }}
+#          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -53,7 +53,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: dist
-        path: dist/ms2pip-*-manylinux1_x86_64.whl
+        path: dist/ms2pip-*-manylinux*.whl
 
   build-macos-wheels:
     runs-on: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,17 +5,16 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:
-        os: [macos-latest]
         python-version: [3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,11 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
       matrix:
+        os: [macos-latest]
         python-version: [3.6, 3.7, 3.8]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ extensions = [
         "ms2pip.cython_modules.ms2pip_pyx",
         sources=["ms2pip/cython_modules/ms2pip_pyx.pyx"] + glob("ms2pip/models/*/*.c"),
         extra_compile_args=[
-            "-fno-var-tracking-assignments",
             "-fno-var-tracking",
             "-Og",
             "-Wno-unused-result",


### PR DESCRIPTION
- Removed `no-var-tracking-assignments` compile argument to support macOS (fixes #19)
- Added macOS build to Build and Publish action
- Update versions of used actions
- Fixed sdist packaging in Build and Publish action (fixes #70)