### PR TITLE
improve handling of errors in modification formatting

### DIFF
--- a/ms2pip/__main__.py
+++ b/ms2pip/__main__.py
@@ -2,14 +2,15 @@ import argparse
 import logging
 import multiprocessing
 
-from ms2pip.exceptions import (
-    InvalidPEPRECError,
-    NoValidPeptideSequencesError,
-    UnknownOutputFormatError,
-    UnknownFragmentationMethodError,
-    FragmentationModelRequiredError)
-from ms2pip.ms2pipC import MS2PIP, SUPPORTED_OUT_FORMATS, MODELS
 from ms2pip.config_parser import ConfigParser
+from ms2pip.exceptions import (FragmentationModelRequiredError,
+                               InvalidModificationFormattingError,
+                               InvalidPEPRECError,
+                               NoValidPeptideSequencesError,
+                               UnknownFragmentationMethodError,
+                               UnknownModificationError,
+                               UnknownOutputFormatError)
+from ms2pip.ms2pipC import MODELS, MS2PIP, SUPPORTED_OUT_FORMATS
 
 
 def print_logo():
@@ -136,6 +137,10 @@ def main():
     except NoValidPeptideSequencesError:
         root_logger.error("No peptides for which to predict intensities. \
             please provide at least one valid peptide sequence.")
+    except UnknownModificationError as e:
+        root_logger.error("Unknown modification: %s", e)
+    except InvalidModificationFormattingError as e:
+        root_logger.error("Invalid formatting of modifications: %s", e)
     except UnknownOutputFormatError as o:
         root_logger.error("Unknown output format: '%s' (supported formats: %s)", o, SUPPORTED_OUT_FORMATS)
     except UnknownFragmentationMethodError as f:

--- a/ms2pip/exceptions.py
+++ b/ms2pip/exceptions.py
@@ -24,3 +24,7 @@ class MissingConfigurationError(Exception):
 
 class FragmentationModelRequiredError(Exception):
     pass
+
+
+class InvalidModificationFormattingError(Exception):
+    pass

--- a/ms2pip/ms2pipC.py
+++ b/ms2pip/ms2pipC.py
@@ -145,15 +145,7 @@ def process_peptides(worker_num, data, afile, modfile, modfile2, PTMmap, model):
 
         # convert peptide string to integer list to speed up C code
         peptide = np.array([0] + [AMINO_ACID_IDS[x] for x in peptide] + [0], dtype=np.uint16)
-
-        try:
-            modpeptide = apply_mods(peptide, mods, PTMmap)
-        except UnknownModificationError as e:
-            logger.warn("Unknown modification: %s", e)
-            continue
-        except InvalidModificationFormattingError as e:
-            logger.error("Invalid formatting of modifications: %s", e)
-            continue
+        modpeptide = apply_mods(peptide, mods, PTMmap)
 
         pepid_buf.append(pepid)
         peplen = len(peptide) - 2
@@ -167,6 +159,7 @@ def process_peptides(worker_num, data, afile, modfile, modfile2, PTMmap, model):
 
         # get ion mzs
         mzs = ms2pip_pyx.get_mzs(modpeptide, peaks_version)
+
         mz_buf.append([np.array(m, dtype=np.float32) for m in mzs])
 
         # Predict the b- and y-ion intensities from the peptide

--- a/ms2pip/ms2pipC.py
+++ b/ms2pip/ms2pipC.py
@@ -90,6 +90,12 @@ MODELS = {
 }
 
 
+def pairwise(iterable):
+    "s -> (s0, s1), (s2, s3), (s4, s5), ..."
+    a = iter(iterable)
+    return zip(a, a)
+
+
 def process_peptides(worker_num, data, afile, modfile, modfile2, PTMmap, model):
     """
     Function for each worker to process a list of peptides. The models are
@@ -129,6 +135,9 @@ def process_peptides(worker_num, data, afile, modfile, modfile2, PTMmap, model):
     charges = specdict["charge"]
     del specdict
 
+    model_id = MODELS[model]["id"]
+    peaks_version = MODELS[model]["peaks_version"]
+
     for pepid in pepids:
         peptide = peptides[pepid]
         peptide = peptide.replace("L", "I")
@@ -141,6 +150,7 @@ def process_peptides(worker_num, data, afile, modfile, modfile2, PTMmap, model):
 
         # Peptides longer then 101 lead to "Segmentation fault (core dumped)"
         if len(peptide) > 100:
+            logger.error("peptide too long: %s", peptide)
             continue
 
         # convert peptide string to integer list to speed up C code
@@ -153,9 +163,6 @@ def process_peptides(worker_num, data, afile, modfile, modfile2, PTMmap, model):
 
         ch = charges[pepid]
         charge_buf.append(ch)
-
-        model_id = MODELS[model]["id"]
-        peaks_version = MODELS[model]["peaks_version"]
 
         # get ion mzs
         mzs = ms2pip_pyx.get_mzs(modpeptide, peaks_version)
@@ -599,6 +606,20 @@ def prepare_titles(titles, num_cpu):
     return split_titles
 
 
+def parse_mods(modstring, PTMmap):
+    if modstring == "-":
+        return []
+    mods = []
+    modstring_parts = modstring.split("|")
+    if len(modstring_parts) % 2 != 0:
+        raise InvalidModificationFormattingError(modstring)
+    for pos, mod in pairwise(modstring_parts):
+        if mod not in PTMmap:
+            raise UnknownModificationError(mod)
+        mods.append((int(pos), PTMmap[mod]))
+    return mods
+
+
 def apply_mods(peptide, mods, PTMmap):
     """
     Takes a peptide sequence and a set of modifications. Returns the modified
@@ -606,18 +627,8 @@ def apply_mods(peptide, mods, PTMmap):
     version are hard coded in ms2pipfeatures_c.c for now.
     """
     modpeptide = np.array(peptide[:], dtype=np.uint16)
-
-    if mods != "-":
-        l = mods.split("|")
-        if len(l) % 2 != 0:
-            raise InvalidModificationFormattingError(mods)
-        for i in range(0, len(l), 2):
-            tl = l[i + 1]
-            if tl in PTMmap:
-                modpeptide[int(l[i])] = PTMmap[tl]
-            else:
-                raise UnknownModificationError(tl)
-
+    for pos, mod in mods:
+        modpeptide[pos] = mod
     return modpeptide
 
 
@@ -821,6 +832,8 @@ class MS2PIP:
     amino acids, or containing B, J, O, U, X or Z).",
                 num_pep_filtered,
             )
+
+        data['modifications'] = data['modifications'].apply(parse_mods, args=(self.mods.ptm_ids,))
 
         if len(data) == 0:
             raise NoValidPeptideSequencesError()


### PR DESCRIPTION
When the modifications are badly formatted, e.g. there is no name of the modification, we currently fail with a rather cryptic index out of range error. Instead we should detect this issue and throw a clear error message.

As a take on #100, I moved handling the error to the main function instead of just ignoring it and skipping the peptide. Now you just get one clear error. I did notice though that ms2pip always exits with exit code 0. We should fix the main function to set an appropriate exit code on failures.