### PR TITLE
fix parsing C-term modifications

### DIFF
--- a/ms2pip/peptides.py
+++ b/ms2pip/peptides.py
@@ -95,8 +95,8 @@ class Modifications:
 
             if amino_acid == "N-term":
                 amino_acid_id = -1
-            elif amino_acid == "N-term":
-                amino_acid_id = -1
+            elif amino_acid == "C-term":
+                amino_acid_id = -2
             elif amino_acid in AMINO_ACID_IDS:
                 amino_acid_id = AMINO_ACID_IDS[amino_acid]
             else:


### PR DESCRIPTION
I just noticed we currently silently skip C-term modifications. Based on the original changeset of 6297c65, this seems to be correct.