### PR TITLE
Build with Numpy 1.16.6

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64"
           CIBW_SKIP: "cp35-* cp39-macosx_x86_64" # see compomics/ms2pip_c#126
-          CIBW_BEFORE_BUILD: "pip install setuptools cython numpy"
+          CIBW_BEFORE_BUILD: "pip install setuptools cython numpy==1.16.6"
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: "pytest {project}/tests"
       - uses: actions/upload-artifact@v2

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ CLASSIFIERS = [
 ]
 INSTALL_REQUIRES = [
     "biopython>=1.74,<2",
-    "numpy>=1.16,<2",
+    "numpy>=1.16.6,<2",
     "pandas>=0.24,<2",
     "pyteomics>=3.5,<5",
     "scipy>=1.2,<2",

--- a/setup.py
+++ b/setup.py
@@ -42,13 +42,13 @@ CLASSIFIERS = [
 ]
 INSTALL_REQUIRES = [
     "biopython>=1.74,<2",
-    "numpy>=1.16.6,<2",
+    "numpy>=1.16,<2",
     "pandas>=0.24,<2",
     "pyteomics>=3.5,<5",
     "scipy>=1.2,<2",
     "tqdm>=4,<5",
     "tables>=3.4",
-    "tomlkit>=0.5.11,<1"
+    "tomlkit>=0.5,<1"
 ]
 PYTHON_REQUIRES = ">=3.6,<4"
 


### PR DESCRIPTION
Packages build with Numpy >=1.20.0 are not backwards compatible with previous Numpy versions. This would lead to an error when starting ms2pip:
```
ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject
```
Building with an earlier Numpy version (1.16.6) should retain forwards compatibility with newer Numpy versions.

See https://numpy.org/doc/stable/release/1.20.0-notes.html#c-api-changes and https://github.com/numpy/numpy/pull/16938.