### PR TITLE
fasta2speclib improvements

### DIFF
--- a/fasta2speclib/fasta2speclib.py
+++ b/fasta2speclib/fasta2speclib.py
@@ -336,10 +336,15 @@ def run_batches(peprec, decoy=False):
         }
     }
 
-    # If add_retention_time, initiate DeepLC (and calibrate once)
+    # If add_retention_time, initiate DeepLC
     if params["add_retention_time"]:
         logging.debug("Initializing DeepLC predictor")
-        rt_predictor = RetentionTime()
+        if "deeplc" in params:
+            if not "n_jobs" in params["deeplc"]:
+                params["deeplc"]["n_jobs"] = params["num_cpu"]
+        else:
+            params["deeplc"] = {"n_jobs": params["num_cpu"]}
+        rt_predictor = RetentionTime(config=params)
 
     # Split up into batches to save memory:
     b_size = params["batch_size"]

--- a/fasta2speclib/fasta2speclib.py
+++ b/fasta2speclib/fasta2speclib.py
@@ -339,11 +339,9 @@ def run_batches(peprec, decoy=False):
     # If add_retention_time, initiate DeepLC
     if params["add_retention_time"]:
         logging.debug("Initializing DeepLC predictor")
-        if "deeplc" in params:
-            if not "n_jobs" in params["deeplc"]:
-                params["deeplc"]["n_jobs"] = params["num_cpu"]
-        else:
-            params["deeplc"] = {"n_jobs": params["num_cpu"]}
+        if "deeplc" not in params:
+            params["deeplc"] = {}
+        params["deeplc"]["n_jobs"] = params["num_cpu"]
         rt_predictor = RetentionTime(config=params)
 
     # Split up into batches to save memory:


### PR DESCRIPTION
- Pass `num_cpu` to DeepLC Predictor, either from the `deeplc` section in the configuration, or from the `num_cpu` option in the fasta2speclib configuration