### PR TITLE
Build with manylinux2014

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -50,6 +50,7 @@ jobs:
         env:
           CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64"
           CIBW_SKIP: "cp35-* cp39-macosx_x86_64" # see compomics/ms2pip_c#126
+          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
           CIBW_BEFORE_BUILD: "pip install setuptools cython numpy==1.16.6"
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: "pytest {project}/tests"


### PR DESCRIPTION
By default 2010 was used, required Numba to be build from source, which failed:
https://github.com/compomics/ms2pip_c/runs/3546479929?check_suite_focus=true