### PR TITLE
Windows support

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -51,11 +51,12 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BUILD: "cp3*-win_amd64"  # No XGBoost wheels for 32bit Windows 
+          CIBW_BUILD: "cp3*-win_amd64"  # No XGBoost wheels for 32bit Windows
+          CIBW_SKIP: "cp39-* cp310-*"  # No pyTables wheels yet...
           #CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64"
           #CIBW_SKIP: "cp35-* cp39-macosx_x86_64" # see compomics/ms2pip_c#126
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
-          CIBW_BEFORE_ALL_WINDOWS: "choco install vcredist140"
+          #CIBW_BEFORE_ALL_WINDOWS: "choco install vcredist140"
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: "pytest {project}/tests"
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -55,6 +55,7 @@ jobs:
           #CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64"
           #CIBW_SKIP: "cp35-* cp39-macosx_x86_64" # see compomics/ms2pip_c#126
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
+          CIBW_BEFORE_ALL_WINDOWS: "choco install vcredist140"
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: "pytest {project}/tests"
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BUILD: "cp3*-win_amd64 cp3*-win32"
+          CIBW_BUILD: "cp3*-win_amd64"  # No XGBoost wheels for 32bit Windows 
           #CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64"
           #CIBW_SKIP: "cp35-* cp39-macosx_x86_64" # see compomics/ms2pip_c#126
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,6 +1,8 @@
 name: Build and publish to PyPI
 
-on: [push]
+on:
+  release:
+    types: [created]
 
 jobs:
   build-sdist:
@@ -63,15 +65,15 @@ jobs:
           name: dist
           path: dist/ms2pip-*.whl
 
-  # publish-to-pypi:
-  #   needs: [build-sdist, build-wheels]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: dist
-  #         path: dist
-  #     - uses: pypa/gh-action-pypi-publish@master
-  #       with:
-  #         user: ${{ secrets.PYPI_USERNAME }}
-  #         password: ${{ secrets.PYPI_PASSWORD }}
+  publish-to-pypi:
+    needs: [build-sdist, build-wheels]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:66
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -33,8 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        #os: [ubuntu-18.04, macos-latest]
-        os: [windows-latest]
+        os: [ubuntu-18.04, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -51,12 +50,11 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BUILD: "cp3*-win_amd64"  # No XGBoost wheels for 32bit Windows
-          CIBW_SKIP: "cp39-* cp310-*"  # No pyTables wheels yet...
-          #CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64"
-          #CIBW_SKIP: "cp35-* cp39-macosx_x86_64" # see compomics/ms2pip_c#126
+          # No XGBoost wheels for 32bit Windows
+          # No PyTables wheels for Python 3.9 and 3.10 yet; see compomics/ms2pip_c#126
+          CIBW_BUILD: "cp3*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64"
+          CIBW_SKIP: "cp39-* cp310-*"
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
-          #CIBW_BEFORE_ALL_WINDOWS: "choco install vcredist140"
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: "pytest {project}/tests"
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -54,6 +54,7 @@ jobs:
           # No PyTables wheels for Python 3.9 and 3.10 yet; see compomics/ms2pip_c#126
           CIBW_BUILD: "cp3*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64"
           CIBW_SKIP: "cp39-* cp310-*"
+          CIBW_BEFORE_ALL_MACOS: "brew install libomp"
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: "pytest {project}/tests"

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,8 +1,6 @@
 name: Build and publish to PyPI
 
-on:
-  release:
-    types: [created]
+on: [push]
 
 jobs:
   build-sdist:
@@ -15,11 +13,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools numpy cython flake8
+          pip install setuptools oldest-supported-numpy cython flake8
       - name: Check for syntax errors
         run: |
           flake8 ./ms2pip ./fasta2speclib --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -35,7 +33,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest]
+        #os: [ubuntu-18.04, macos-latest]
+        os: [windows-latest]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -43,17 +42,18 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.10'
       - name: Check for syntax errors
         run: |
           pip install flake8
           flake8 ./ms2pip ./fasta2speclib --count --select=E9,F63,F7,F82 --show-source --statistics
-      - uses: joerick/cibuildwheel@v1.7.4
+      - uses: joerick/cibuildwheel@v2.2.2
         with:
           output-dir: dist
         env:
-          CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64"
-          CIBW_SKIP: "cp35-* cp39-macosx_x86_64" # see compomics/ms2pip_c#126
+          CIBW_BUILD: "cp3*-win_amd64 cp3*-win32"
+          #CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64"
+          #CIBW_SKIP: "cp35-* cp39-macosx_x86_64" # see compomics/ms2pip_c#126
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: "pytest {project}/tests"
@@ -62,15 +62,15 @@ jobs:
           name: dist
           path: dist/ms2pip-*.whl
 
-  publish-to-pypi:
-    needs: [build-sdist, build-wheels]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist
-          path: dist
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}
+  # publish-to-pypi:
+  #   needs: [build-sdist, build-wheels]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: dist
+  #         path: dist
+  #     - uses: pypa/gh-action-pypi-publish@master
+  #       with:
+  #         user: ${{ secrets.PYPI_USERNAME }}
+  #         password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v2
-        with:66
+        with:
           name: dist
           path: dist
       - uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Tests
 
-on: [push, pull_request]
+#on: [push, pull_request]
+on: release  # temporarily disable
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,11 @@
 name: Tests
 
 #on: [push, pull_request]
-on: release  # temporarily disable
+on:
+  push:
+    branches:
+      - releases
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,5 @@
 name: Tests
 
-#on: [push, pull_request]
 on:
   push:
     branches:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ With Python 3.6 or higher, run:
 pip install ms2pip
 ```
 
+Compiled wheels are available for Python 3.6, 3.7, and 3.8, on 64bit Linux,
+Windows, and macOS. This should install MS²PIP in a few seconds. For other
+platforms, MS²PIP can be built from source, although it can take up to one hour
+to compile the large prediction models.
+
 We recommend using a [venv](https://docs.python.org/3/library/venv.html) or
 [conda](https://docs.conda.io/en/latest/) virtual environment.
 
@@ -85,6 +90,8 @@ Install with activated bioconda and conda-forge channels:
 ```
 conda install -c defaults -c bioconda -c conda-forge ms2pip
 ```
+
+Conda packages are only available for Linux and macOS.
 
 #### Docker container
 First check the latest version tag on [biocontainers/ms2pip/tags](https://quay.io/repository/biocontainers/ms2pip?tab=tags). Then pull and run the container with

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Install with activated bioconda and conda-forge channels:
 conda install -c defaults -c bioconda -c conda-forge ms2pip
 ```
 
-Conda packages are only available for Linux and macOS.
+Bioconda packages are only available for Linux and macOS.
 
 #### Docker container
 First check the latest version tag on [biocontainers/ms2pip/tags](https://quay.io/repository/biocontainers/ms2pip?tab=tags). Then pull and run the container with

--- a/ms2pip/cython_modules/ms2pip_peaks_c.c
+++ b/ms2pip/cython_modules/ms2pip_peaks_c.c
@@ -8,12 +8,12 @@
 #include "ms2pip_features_c_old.c"
 #include "ms2pip_features_c_catboost.c"
 
-// #include "../models/CID.h"
+#include "../models/CID.h"
 #include "../models/HCD-2019.h"
-// #include "../models/TTOF5600.h"
-// #include "../models/TMT.h"
-// #include "../models/iTRAQ.h"
-// #include "../models/iTRAQphospho.h"
+#include "../models/TTOF5600.h"
+#include "../models/TMT.h"
+#include "../models/iTRAQ.h"
+#include "../models/iTRAQphospho.h"
 
 float membuffer[10000];
 float ions[2000];
@@ -34,52 +34,52 @@ float* get_p_ms2pip(int peplen, unsigned short* peptide, unsigned short* modpept
 	int i;
 
 	// CID
-	// if (model_id == 0) {
-	// 	for (i=0; i < peplen-1; i++) {
-	// 		predictions[0*(peplen-1)+i] = score_CID_B(v+1+(i*fnum))+0.5;
-	// 		predictions[2*(peplen-1)-i-1] = score_CID_Y(v+1+(i*fnum))+0.5;
-	// 	}
-	// }
+	if (model_id == 0) {
+		for (i=0; i < peplen-1; i++) {
+			predictions[0*(peplen-1)+i] = score_CID_B(v+1+(i*fnum))+0.5;
+			predictions[2*(peplen-1)-i-1] = score_CID_Y(v+1+(i*fnum))+0.5;
+		}
+	}
 
 	// HCD
-	if (model_id == 1) {
+	else if (model_id == 1) {
 		for (i=0; i < peplen-1; i++) {
 			predictions[0*(peplen-1)+i] = score_HCD_B(v+1+(i*fnum))+0.5;
 			predictions[2*(peplen-1)-i-1] = score_HCD_Y(v+1+(i*fnum))+0.5;
 		}
 	}
 
-	// // TTOF5600
-	// else if (model_id == 2) {
-	// 	for (i=0; i < peplen-1; i++) {
-	// 		predictions[0*(peplen-1)+i] = score_TTOF5600_B(v+1+(i*fnum))+0.5;
-	// 		predictions[2*(peplen-1)-i-1] = score_TTOF5600_Y(v+1+(i*fnum))+0.5;
-	// 	}
-	// }
+	// TTOF5600
+	else if (model_id == 2) {
+		for (i=0; i < peplen-1; i++) {
+			predictions[0*(peplen-1)+i] = score_TTOF5600_B(v+1+(i*fnum))+0.5;
+			predictions[2*(peplen-1)-i-1] = score_TTOF5600_Y(v+1+(i*fnum))+0.5;
+		}
+	}
 
-	// // TMT
-	// else if (model_id == 3) {
-	// 	for (i=0; i < peplen-1; i++) {
-	// 	    predictions[0*(peplen-1)+i] = score_TMT_B(v+1+(i*fnum))+0.5;
-	// 	    predictions[2*(peplen-1)-i-1] = score_TMT_Y(v+1+(i*fnum))+0.5;
-	// 	}
-	// }
+	// TMT
+	else if (model_id == 3) {
+		for (i=0; i < peplen-1; i++) {
+		    predictions[0*(peplen-1)+i] = score_TMT_B(v+1+(i*fnum))+0.5;
+		    predictions[2*(peplen-1)-i-1] = score_TMT_Y(v+1+(i*fnum))+0.5;
+		}
+	}
 
-	// // iTRAQ
-	// else if (model_id == 4) {
-	// 	for (i=0; i < peplen-1; i++) {
-	// 		predictions[0*(peplen-1)+i] = score_iTRAQ_B(v+1+(i*fnum))+0.5;
-	// 		predictions[2*(peplen-1)-i-1] = score_iTRAQ_Y(v+1+(i*fnum))+0.5;
-	// 	}
-	// }
+	// iTRAQ
+	else if (model_id == 4) {
+		for (i=0; i < peplen-1; i++) {
+			predictions[0*(peplen-1)+i] = score_iTRAQ_B(v+1+(i*fnum))+0.5;
+			predictions[2*(peplen-1)-i-1] = score_iTRAQ_Y(v+1+(i*fnum))+0.5;
+		}
+	}
 
-	// // iTRAQphospho
-	// else if (model_id == 5) {
-	// 	for (i=0; i < peplen-1; i++) {
-	// 		predictions[0*(peplen-1)+i] = score_iTRAQphospho_B(v+1+(i*fnum))+0.5;
-	// 		predictions[2*(peplen-1)-i-1] = score_iTRAQphospho_Y(v+1+(i*fnum))+0.5;
-	// 	}
-	// }
+	// iTRAQphospho
+	else if (model_id == 5) {
+		for (i=0; i < peplen-1; i++) {
+			predictions[0*(peplen-1)+i] = score_iTRAQphospho_B(v+1+(i*fnum))+0.5;
+			predictions[2*(peplen-1)-i-1] = score_iTRAQphospho_Y(v+1+(i*fnum))+0.5;
+		}
+	}
 
 	// EThcD
 	// else if (model_id == 6) {
@@ -91,25 +91,25 @@ float* get_p_ms2pip(int peplen, unsigned short* peptide, unsigned short* modpept
 	// 	}
 	// }
 
-	// // HCDch2
-	// else if (model_id == 7) {
-	// 	for (i=0; i < peplen-1; i++) {
-	// 		predictions[0*(peplen-1)+i] = score_HCD_B(v+1+(i*fnum))+0.5;
-	// 		predictions[2*(peplen-1)-i-1] = score_HCD_Y(v+1+(i*fnum))+0.5;
-	// 		predictions[2*(peplen-1)+i] = score_HCD_B2(v+1+(i*fnum))+0.5;
-	// 		predictions[4*(peplen-1)-i-1] = score_HCD_Y2(v+1+(i*fnum))+0.5;
-	// 	}
-	// }
+	// HCDch2
+	else if (model_id == 7) {
+		for (i=0; i < peplen-1; i++) {
+			predictions[0*(peplen-1)+i] = score_HCD_B(v+1+(i*fnum))+0.5;
+			predictions[2*(peplen-1)-i-1] = score_HCD_Y(v+1+(i*fnum))+0.5;
+			predictions[2*(peplen-1)+i] = score_HCD_B2(v+1+(i*fnum))+0.5;
+			predictions[4*(peplen-1)-i-1] = score_HCD_Y2(v+1+(i*fnum))+0.5;
+		}
+	}
 
-	// // CIDch2
-	// else if (model_id == 8) {
-	// 	for (i=0; i < peplen-1; i++) {
-	// 	    predictions[0*(peplen-1)+i] = score_CID_B(v+1+(i*fnum))+0.5;
-	// 	    predictions[2*(peplen-1)-i-1] = score_CID_Y(v+1+(i*fnum))+0.5;
-	// 	    predictions[2*(peplen-1)+i] = score_CID_B2(v+1+(i*fnum))+0.5;
-	// 	    predictions[4*(peplen-1)-i-1] = score_CID_Y2(v+1+(i*fnum))+0.5;
-	// 	}
-	// }
+	// CIDch2
+	else if (model_id == 8) {
+		for (i=0; i < peplen-1; i++) {
+		    predictions[0*(peplen-1)+i] = score_CID_B(v+1+(i*fnum))+0.5;
+		    predictions[2*(peplen-1)-i-1] = score_CID_Y(v+1+(i*fnum))+0.5;
+		    predictions[2*(peplen-1)+i] = score_CID_B2(v+1+(i*fnum))+0.5;
+		    predictions[4*(peplen-1)-i-1] = score_CID_Y2(v+1+(i*fnum))+0.5;
+		}
+	}
 	else {
 		return NULL;
 	}

--- a/ms2pip/cython_modules/ms2pip_peaks_c.c
+++ b/ms2pip/cython_modules/ms2pip_peaks_c.c
@@ -8,12 +8,12 @@
 #include "ms2pip_features_c_old.c"
 #include "ms2pip_features_c_catboost.c"
 
-#include "../models/CID.h"
+// #include "../models/CID.h"
 #include "../models/HCD-2019.h"
-#include "../models/TTOF5600.h"
-#include "../models/TMT.h"
-#include "../models/iTRAQ.h"
-#include "../models/iTRAQphospho.h"
+// #include "../models/TTOF5600.h"
+// #include "../models/TMT.h"
+// #include "../models/iTRAQ.h"
+// #include "../models/iTRAQphospho.h"
 
 float membuffer[10000];
 float ions[2000];
@@ -34,52 +34,52 @@ float* get_p_ms2pip(int peplen, unsigned short* peptide, unsigned short* modpept
 	int i;
 
 	// CID
-	if (model_id == 0) {
-		for (i=0; i < peplen-1; i++) {
-			predictions[0*(peplen-1)+i] = score_CID_B(v+1+(i*fnum))+0.5;
-			predictions[2*(peplen-1)-i-1] = score_CID_Y(v+1+(i*fnum))+0.5;
-		}
-	}
+	// if (model_id == 0) {
+	// 	for (i=0; i < peplen-1; i++) {
+	// 		predictions[0*(peplen-1)+i] = score_CID_B(v+1+(i*fnum))+0.5;
+	// 		predictions[2*(peplen-1)-i-1] = score_CID_Y(v+1+(i*fnum))+0.5;
+	// 	}
+	// }
 
 	// HCD
-	else if (model_id == 1) {
+	if (model_id == 1) {
 		for (i=0; i < peplen-1; i++) {
 			predictions[0*(peplen-1)+i] = score_HCD_B(v+1+(i*fnum))+0.5;
 			predictions[2*(peplen-1)-i-1] = score_HCD_Y(v+1+(i*fnum))+0.5;
 		}
 	}
 
-	// TTOF5600
-	else if (model_id == 2) {
-		for (i=0; i < peplen-1; i++) {
-			predictions[0*(peplen-1)+i] = score_TTOF5600_B(v+1+(i*fnum))+0.5;
-			predictions[2*(peplen-1)-i-1] = score_TTOF5600_Y(v+1+(i*fnum))+0.5;
-		}
-	}
+	// // TTOF5600
+	// else if (model_id == 2) {
+	// 	for (i=0; i < peplen-1; i++) {
+	// 		predictions[0*(peplen-1)+i] = score_TTOF5600_B(v+1+(i*fnum))+0.5;
+	// 		predictions[2*(peplen-1)-i-1] = score_TTOF5600_Y(v+1+(i*fnum))+0.5;
+	// 	}
+	// }
 
-	// TMT
-	else if (model_id == 3) {
-		for (i=0; i < peplen-1; i++) {
-		    predictions[0*(peplen-1)+i] = score_TMT_B(v+1+(i*fnum))+0.5;
-		    predictions[2*(peplen-1)-i-1] = score_TMT_Y(v+1+(i*fnum))+0.5;
-		}
-	}
+	// // TMT
+	// else if (model_id == 3) {
+	// 	for (i=0; i < peplen-1; i++) {
+	// 	    predictions[0*(peplen-1)+i] = score_TMT_B(v+1+(i*fnum))+0.5;
+	// 	    predictions[2*(peplen-1)-i-1] = score_TMT_Y(v+1+(i*fnum))+0.5;
+	// 	}
+	// }
 
-	// iTRAQ
-	else if (model_id == 4) {
-		for (i=0; i < peplen-1; i++) {
-			predictions[0*(peplen-1)+i] = score_iTRAQ_B(v+1+(i*fnum))+0.5;
-			predictions[2*(peplen-1)-i-1] = score_iTRAQ_Y(v+1+(i*fnum))+0.5;
-		}
-	}
+	// // iTRAQ
+	// else if (model_id == 4) {
+	// 	for (i=0; i < peplen-1; i++) {
+	// 		predictions[0*(peplen-1)+i] = score_iTRAQ_B(v+1+(i*fnum))+0.5;
+	// 		predictions[2*(peplen-1)-i-1] = score_iTRAQ_Y(v+1+(i*fnum))+0.5;
+	// 	}
+	// }
 
-	// iTRAQphospho
-	else if (model_id == 5) {
-		for (i=0; i < peplen-1; i++) {
-			predictions[0*(peplen-1)+i] = score_iTRAQphospho_B(v+1+(i*fnum))+0.5;
-			predictions[2*(peplen-1)-i-1] = score_iTRAQphospho_Y(v+1+(i*fnum))+0.5;
-		}
-	}
+	// // iTRAQphospho
+	// else if (model_id == 5) {
+	// 	for (i=0; i < peplen-1; i++) {
+	// 		predictions[0*(peplen-1)+i] = score_iTRAQphospho_B(v+1+(i*fnum))+0.5;
+	// 		predictions[2*(peplen-1)-i-1] = score_iTRAQphospho_Y(v+1+(i*fnum))+0.5;
+	// 	}
+	// }
 
 	// EThcD
 	// else if (model_id == 6) {
@@ -91,25 +91,25 @@ float* get_p_ms2pip(int peplen, unsigned short* peptide, unsigned short* modpept
 	// 	}
 	// }
 
-	// HCDch2
-	else if (model_id == 7) {
-		for (i=0; i < peplen-1; i++) {
-			predictions[0*(peplen-1)+i] = score_HCD_B(v+1+(i*fnum))+0.5;
-			predictions[2*(peplen-1)-i-1] = score_HCD_Y(v+1+(i*fnum))+0.5;
-			predictions[2*(peplen-1)+i] = score_HCD_B2(v+1+(i*fnum))+0.5;
-			predictions[4*(peplen-1)-i-1] = score_HCD_Y2(v+1+(i*fnum))+0.5;
-		}
-	}
+	// // HCDch2
+	// else if (model_id == 7) {
+	// 	for (i=0; i < peplen-1; i++) {
+	// 		predictions[0*(peplen-1)+i] = score_HCD_B(v+1+(i*fnum))+0.5;
+	// 		predictions[2*(peplen-1)-i-1] = score_HCD_Y(v+1+(i*fnum))+0.5;
+	// 		predictions[2*(peplen-1)+i] = score_HCD_B2(v+1+(i*fnum))+0.5;
+	// 		predictions[4*(peplen-1)-i-1] = score_HCD_Y2(v+1+(i*fnum))+0.5;
+	// 	}
+	// }
 
-	// CIDch2
-	else if (model_id == 8) {
-		for (i=0; i < peplen-1; i++) {
-		    predictions[0*(peplen-1)+i] = score_CID_B(v+1+(i*fnum))+0.5;
-		    predictions[2*(peplen-1)-i-1] = score_CID_Y(v+1+(i*fnum))+0.5;
-		    predictions[2*(peplen-1)+i] = score_CID_B2(v+1+(i*fnum))+0.5;
-		    predictions[4*(peplen-1)-i-1] = score_CID_Y2(v+1+(i*fnum))+0.5;
-		}
-	}
+	// // CIDch2
+	// else if (model_id == 8) {
+	// 	for (i=0; i < peplen-1; i++) {
+	// 	    predictions[0*(peplen-1)+i] = score_CID_B(v+1+(i*fnum))+0.5;
+	// 	    predictions[2*(peplen-1)-i-1] = score_CID_Y(v+1+(i*fnum))+0.5;
+	// 	    predictions[2*(peplen-1)+i] = score_CID_B2(v+1+(i*fnum))+0.5;
+	// 	    predictions[4*(peplen-1)-i-1] = score_CID_Y2(v+1+(i*fnum))+0.5;
+	// 	}
+	// }
 	else {
 		return NULL;
 	}

--- a/ms2pip/ms2pipC.py
+++ b/ms2pip/ms2pipC.py
@@ -120,6 +120,7 @@ MODELS = {
         }
     },
 }
+MODELS["HCD"] = MODELS["HCD2021"]
 
 
 def process_peptides(worker_num, data, afile, modfile, modfile2, PTMmap, model):

--- a/setup.py
+++ b/setup.py
@@ -70,13 +70,14 @@ to_remove = [
 extensions = [
     Extension(
         "ms2pip.cython_modules.ms2pip_pyx",
-        sources=["ms2pip/cython_modules/ms2pip_pyx.pyx"] + glob("ms2pip/models/*/*.c"),
+        sources=["ms2pip/cython_modules/ms2pip_pyx.pyx"] + glob("ms2pip/models/HCD-2019/*.c"),
         extra_compile_args=[
-            "-fno-var-tracking",
-            "-Og",
-            "-Wno-unused-result",
-            "-Wno-cpp",
-            "-Wno-unused-function",
+            #"-fno-var-tracking",
+            "-wd4244"
+            #"-Og",
+            #"-Wno-unused-result",
+            #"-Wno-cpp",
+            #"-Wno-unused-function",
         ],
     )
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import platform
 from glob import glob
 
 from setuptools import setup
@@ -67,18 +68,32 @@ to_remove = [
 ]
 #_ = [[os.remove(f) for f in glob(pat)] for pat in to_remove]
 
+# Large machine-written C model files require optimization to be disabled
+compile_args = {
+    "Linux": [
+        "-O0",
+        "-fno-var-tracking",
+        "-Wno-unused-result",
+        "-Wno-cpp",
+        "-Wno-unused-function",
+    ],
+    "Darwin": [
+        "-O0",
+    ],
+    "Windows": [    
+        "/Od",
+        "/DEBUG",
+        "/GL-",
+        "/bigobj",
+        "-wd4244",
+    ]
+}
+
 extensions = [
     Extension(
         "ms2pip.cython_modules.ms2pip_pyx",
         sources=["ms2pip/cython_modules/ms2pip_pyx.pyx"] + glob("ms2pip/models/HCD-2019/*.c"),
-        extra_compile_args=[
-            #"-fno-var-tracking",
-            "-wd4244"
-            #"-Og",
-            #"-Wno-unused-result",
-            #"-Wno-cpp",
-            #"-Wno-unused-function",
-        ],
+        extra_compile_args=compile_args[platform.system()],
     )
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -85,14 +85,14 @@ compile_args = {
         "/DEBUG",
         "/GL-",
         "/bigobj",
-        "-wd4244",
+        "/wd4244",
     ]
 }
 
 extensions = [
     Extension(
         "ms2pip.cython_modules.ms2pip_pyx",
-        sources=["ms2pip/cython_modules/ms2pip_pyx.pyx"] + glob("ms2pip/models/HCD-2019/*.c"),
+        sources=["ms2pip/cython_modules/ms2pip_pyx.pyx"] + glob("ms2pip/models/*/*.c"),
         extra_compile_args=compile_args[platform.system()],
     )
 ]


### PR DESCRIPTION
Add support for Windows.

To do:
- [x] Make extra compile arguments compatible
- [x] Add Windows to build platforms in cibuildwheel action
- [x] Update readme

Extra:
- [x] Made `HCD` model name synonymous to `HCD2021` for backwards compatibility
- [x] Fixed build for macOS: Missing XGBoost dependency in build environment: `libomp`
- [x] Avoid extra test runs due to `on: [push, pull_request]` by specifying push branch

Caveats for compiled wheels: 
- 32bit platforms not built, as XGBoost wheels are missing
- Python 3.9 and 3.10 not built, as pyTables wheels are missing: PyTables/PyTables#823