### PR TITLE
Include python 3.9 and 3.10 in build, drop 3.6

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,6 +1,7 @@
 name: Build and publish to PyPI
 
 on:
+  push:
   release:
     types: [created]
 
@@ -65,15 +66,15 @@ jobs:
           name: dist
           path: dist/ms2pip-*.whl
 
-  publish-to-pypi:
-    needs: [build-sdist, build-wheels]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist
-          path: dist
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}
+  # publish-to-pypi:
+  #   needs: [build-sdist, build-wheels]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: dist
+  #         path: dist
+  #     - uses: pypa/gh-action-pypi-publish@master
+  #       with:
+  #         user: ${{ secrets.PYPI_USERNAME }}
+  #         password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -46,16 +46,16 @@ jobs:
           python-version: '3.10'
       - name: Check for syntax errors
         run: |
-          pip install flake8
+          python -m pip install flake8
           flake8 ./ms2pip ./fasta2speclib --count --select=E9,F63,F7,F82 --show-source --statistics
-      - uses: joerick/cibuildwheel@v2.2.2
-        with:
-          output-dir: dist
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.3.1
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir dist
         env:
           # No XGBoost wheels for 32bit Windows
-          # No PyTables wheels for Python 3.9 and 3.10 yet; see compomics/ms2pip_c#126
           CIBW_BUILD: "cp3*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64"
-          CIBW_SKIP: "cp39-* cp310-*"
+          CIBW_SKIP: "cp36-*"  # EOL
           CIBW_BEFORE_ALL_MACOS: "brew install libomp"
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
           CIBW_TEST_REQUIRES: "pytest"

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -78,3 +78,4 @@ jobs:
   #       with:
   #         user: ${{ secrets.PYPI_USERNAME }}
   #         password: ${{ secrets.PYPI_PASSWORD }}
+  #

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,7 +1,6 @@
 name: Build and publish to PyPI
 
 on:
-  push:
   release:
     types: [created]
 
@@ -66,16 +65,16 @@ jobs:
           name: dist
           path: dist/ms2pip-*.whl
 
-  # publish-to-pypi:
-  #   needs: [build-sdist, build-wheels]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: dist
-  #         path: dist
-  #     - uses: pypa/gh-action-pypi-publish@master
-  #       with:
-  #         user: ${{ secrets.PYPI_USERNAME }}
-  #         password: ${{ secrets.PYPI_PASSWORD }}
-  #
+  publish-to-pypi:
+    needs: [build-sdist, build-wheels]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}
+  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- 3.9/3.10: Blocking upstream issue (PyTables/PyTables#823) fixed (#126)
- 3.6: End-of-life