### PR TITLE
Spectrum reader changes

### DIFF
--- a/ms2pip/ms2pipC.py
+++ b/ms2pip/ms2pipC.py
@@ -377,9 +377,11 @@ def process_spectra(
         peptide = peptides[title]
         peptide = peptide.replace("L", "I")
         mods = modifications[title]
-        
-        if not spectrum.charge:
-            spectrum.charge = charges[title] # if charge cannot be parsed from mgf
+
+        if spectrum.precursor_charge:
+            charge = spectrum.precursor_charge
+        else:
+            charge = charges[title]  # If charge cannot be parsed from MGF
 
         if "mut" in mods:
             continue
@@ -432,7 +434,7 @@ def process_spectra(
                 dvectors.append(
                     np.array(
                         ms2pip_pyx.get_vector_ce(
-                            peptide, modpeptide, spectrum.charge, colen
+                            peptide, modpeptide, charge, colen
                         ),
                         dtype=np.uint16,
                     )
@@ -440,7 +442,7 @@ def process_spectra(
             else:
                 dvectors.append(
                     np.array(
-                        ms2pip_pyx.get_vector(peptide, modpeptide, spectrum.charge),
+                        ms2pip_pyx.get_vector(peptide, modpeptide, charge),
                         dtype=np.uint16,
                     )
                 )
@@ -464,7 +466,7 @@ def process_spectra(
             # Predict the b- and y-ion intensities from the peptide
             pepid_buf.append(title)
             peplen_buf.append(len(peptide) - 2)
-            charge_buf.append(spectrum.charge)
+            charge_buf.append(charge)
 
             # get/append ion mzs, targets and predictions
             targets = ms2pip_pyx.get_targets(
@@ -483,13 +485,13 @@ def process_spectra(
             if "xgboost_model_files" in MODELS[model].keys():
                 vector_buf.append(
                     np.array(
-                        ms2pip_pyx.get_vector(peptide, modpeptide, spectrum.charge),
+                        ms2pip_pyx.get_vector(peptide, modpeptide, charge),
                         dtype=np.uint16,
                     )
                 )
             else:
                 predictions = ms2pip_pyx.get_predictions(
-                    peptide, modpeptide, spectrum.charge, model_id, peaks_version, colen
+                    peptide, modpeptide, charge, model_id, peaks_version, colen
                 )
                 prediction_buf.append(
                     [np.array(p, dtype=np.float32) for p in predictions]

--- a/ms2pip/ms2pipC.py
+++ b/ms2pip/ms2pipC.py
@@ -324,10 +324,11 @@ def process_spectra(
         ces = specdict["ce"]
     else:
         specdict = (
-            data[["spec_id", "peptide", "modifications"]].set_index("spec_id").to_dict()
+            data[["spec_id", "peptide", "modifications", "charge"]].set_index("spec_id").to_dict()
         )
     peptides = specdict["peptide"]
     modifications = specdict["modifications"]
+    charges = specdict["charge"]
 
     # cols contains the names of the computed features
     cols_n = get_feature_names_new()
@@ -376,6 +377,9 @@ def process_spectra(
         peptide = peptides[title]
         peptide = peptide.replace("L", "I")
         mods = modifications[title]
+        
+        if not spectrum.charge:
+            spectrum.charge = charges[title] # if charge cannot be parsed from mgf
 
         if "mut" in mods:
             continue

--- a/ms2pip/spectrum.py
+++ b/ms2pip/spectrum.py
@@ -91,7 +91,6 @@ def read_mgf(spec_file) -> Generator[Spectrum, None, None]:
             spec_id = spectrum["params"]["title"]
             peaks = spectrum["intensity array"]
             msms = spectrum["m/z array"]
-            # precursor_mz = spectrum["params"]["pepmass"][0]
             try:
                 precursor_charge = spectrum["params"]["charge"][0]
             except KeyError:
@@ -129,10 +128,12 @@ def read_mzml(spec_file) -> Generator[Spectrum, None, None]:
                 precursor = spectrum["precursorList"]["precursor"][0][
                     "selectedIonList"
                 ]["selectedIon"][0]
-                precursor_mz = precursor["selected ion m/z"]
-                precursor_charge = precursor["charge state"]
+                try:
+                    precursor_charge = precursor["charge state"]
+                except KeyError:
+                    precursor_charge = None
                 parsed_spectrum = Spectrum(
-                    spec_id, precursor_charge, precursor_mz, msms, peaks
+                    spec_id, msms, peaks, precursor_charge
                 )
                 yield parsed_spectrum
 

--- a/ms2pip/spectrum.py
+++ b/ms2pip/spectrum.py
@@ -14,11 +14,11 @@ from ms2pip.exceptions import (
 
 
 class Spectrum:
-    def __init__(self, title, charge, pepmass, msms, peaks) -> None:
+    def __init__(self, title, msms, peaks, charge) -> None:
         """Minimal information on observed MS2 spectrum."""
         self.title = str(title)
-        self.charge = int(charge)
-        self.pepmass = float(pepmass)
+        self.charge = charge
+        # self.pepmass = float(pepmass)
         self.msms = np.array(msms, dtype=np.float32)
         self.peaks = np.array(peaks, dtype=np.float32)
 
@@ -91,10 +91,14 @@ def read_mgf(spec_file) -> Generator[Spectrum, None, None]:
             spec_id = spectrum["params"]["title"]
             peaks = spectrum["intensity array"]
             msms = spectrum["m/z array"]
-            precursor_mz = spectrum["params"]["pepmass"][0]
-            precursor_charge = spectrum["params"]["charge"][0]
+            # precursor_mz = spectrum["params"]["pepmass"][0]
+            try:
+                precursor_charge = spectrum["params"]["charge"][0]
+            except KeyError:
+                precursor_charge = None
+
             parsed_spectrum = Spectrum(
-                spec_id, precursor_charge, precursor_mz, msms, peaks
+                spec_id, msms, peaks, precursor_charge
             )
             yield parsed_spectrum
 


### PR DESCRIPTION
### Fixed
- If the precursor charge is not found in the MGF file, the charge from the PeptideRecord file is used instead.