### PR TITLE
Update URL to download models

### DIFF
--- a/ms2pip/_utils/xgb_models.py
+++ b/ms2pip/_utils/xgb_models.py
@@ -53,7 +53,7 @@ def get_predictions_xgb(features, num_ions, model_params, model_dir, processes=1
     for ion_type, xgb_model in xgboost_models.items():
         # Get predictions from XGBoost model
         preds = xgb_model.predict(features)
-        preds = preds.clip(min=np.log2(0.001)) # Clip negative intensities
+        preds = preds.clip(min=np.log2(0.001))  # Clip negative intensities
         xgb_model.__del__()
 
         # Reshape into arrays for each peptide
@@ -96,9 +96,7 @@ def _download_model(model, model_hash, model_dir):
     filename = os.path.join(model_dir, model)
 
     logger.info(f"Downloading {model} to {filename}...")
-    urllib.request.urlretrieve(
-        os.path.join("https://genesis.ugent.be/uvpublicdata/ms2pip/", model), filename
-    )
+    urllib.request.urlretrieve(f"https://zenodo.org/records/13270668/files/{model}", filename)
     if not _check_model_integrity(filename, model_hash):
         raise InvalidXGBoostModelError()
 

--- a/ms2pip/_utils/xgb_models.py
+++ b/ms2pip/_utils/xgb_models.py
@@ -97,7 +97,7 @@ def _download_model(model, model_hash, model_dir):
 
     logger.info(f"Downloading {model} to {filename}...")
     urllib.request.urlretrieve(
-        os.path.join("http://genesis.ugent.be/uvpublicdata/ms2pip/", model), filename
+        os.path.join("https://genesis.ugent.be/uvpublicdata/ms2pip/", model), filename
     )
     if not _check_model_integrity(filename, model_hash):
         raise InvalidXGBoostModelError()


### PR DESCRIPTION
There is a checksum check, and server-side there is a redirect to https, but that also means there is no point in not using https right away.

---

### Changed

- Download model files from Zenodo instead of Genesis server