### PR TITLE
support reading gzipped spectrum files

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -65,7 +65,7 @@ For instance:
 
 .. code-block:: sh
 
-    ms2pip correlate results.sage.tsv --spectrum-file spectra.mgf
+    ms2pip correlate --psm-filetype sage results.sage.tsv spectra.mgf
 
 
 ``get-training-data``

--- a/ms2pip/spectrum_input.py
+++ b/ms2pip/spectrum_input.py
@@ -29,8 +29,17 @@ def read_spectrum_file(spectrum_file: str) -> Generator[ObservedSpectrum, None, 
         If the file extension is not supported.
 
     """
-    file_extension = Path(spectrum_file).suffix.lower()
-    if file_extension not in [".mgf", ".mzml", ".d"] and not _is_minitdf(spectrum_file):
+    spectrum_path = Path(spectrum_file)
+    file_extension = spectrum_path.suffix.lower()
+    if (
+        file_extension not in [".mgf", ".mzml", ".raw", ".d"]
+        and not (
+            file_extension == ".gz"
+            and len(spectrum_path.suffixes) > 1
+            and spectrum_path.suffixes[-2].lower() in [".mgf", ".mzml"]
+        )
+        and not _is_minitdf(spectrum_file)
+    ):
         raise UnsupportedSpectrumFiletypeError(file_extension)
 
     for spectrum in get_ms2_spectra(str(spectrum_file)):

--- a/ms2pip/spectrum_input.py
+++ b/ms2pip/spectrum_input.py
@@ -51,15 +51,3 @@ def read_spectrum_file(spectrum_file: str) -> Generator[ObservedSpectrum, None, 
         ):
             continue
         yield obs_spectrum
-
-
-def _is_minitdf(spectrum_file: str) -> bool:
-    """
-    Check if the spectrum file is a Bruker miniTDF folder.
-
-    A Bruker miniTDF folder has no fixed name, but contains files matching the patterns
-    ``*ms2spectrum.bin`` and ``*ms2spectrum.parquet``.
-    """
-    files = set(Path(spectrum_file).glob("*ms2spectrum.bin"))
-    files.update(Path(spectrum_file).glob("*ms2spectrum.parquet"))
-    return len(files) >= 2

--- a/ms2pip/spectrum_input.py
+++ b/ms2pip/spectrum_input.py
@@ -29,20 +29,12 @@ def read_spectrum_file(spectrum_file: str) -> Generator[ObservedSpectrum, None, 
         If the file extension is not supported.
 
     """
-    spectrum_path = Path(spectrum_file)
-    file_extension = spectrum_path.suffix.lower()
-    if (
-        file_extension not in [".mgf", ".mzml", ".raw", ".d"]
-        and not (
-            file_extension == ".gz"
-            and len(spectrum_path.suffixes) > 1
-            and spectrum_path.suffixes[-2].lower() in [".mgf", ".mzml"]
-        )
-        and not _is_minitdf(spectrum_file)
-    ):
-        raise UnsupportedSpectrumFiletypeError(file_extension)
+    try:
+        spectra = get_ms2_spectra(str(spectrum_file))
+    except ValueError:
+        raise UnsupportedSpectrumFiletypeError(Path(spectrum_file).suffixes)
 
-    for spectrum in get_ms2_spectra(str(spectrum_file)):
+    for spectrum in spectra:
         obs_spectrum = ObservedSpectrum(
             mz=np.array(spectrum.mz, dtype=np.float32),
             intensity=np.array(spectrum.intensity, dtype=np.float32),


### PR DESCRIPTION
Drop file type check and instead catch exception thrown by ms2rescore-rs if the file type is unsupported. When used with https://github.com/compomics/ms2rescore-rs/pull/1, this adds support for gzipped spectrum files.

As an alternative, we could also use the `is_supported_file_type` function introduced in that pull request.

---

### Added

- Support for gzipped spectrum files
- Support for Thermo Raw files (requires dotnet runtime)

