### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -3,6 +3,7 @@ name: Build and publish to PyPI
 on:
   release:
     types: [created]
+  pull_request:  # for testing
 
 jobs:
   build-sdist:
@@ -46,18 +47,18 @@ jobs:
           name: dist-${{ matrix.os }}
           path: dist
 
-  publish-to-pypi:
-    needs: [build-sdist, build-wheels]
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/ms2pip
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@v4
-      - name: Move wheels to dist
-        run: |
-          mv wheels-*/*.whl dist/
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+  # publish-to-pypi:
+  #   needs: [build-sdist, build-wheels]
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: pypi
+  #     url: https://pypi.org/p/ms2pip
+  #   permissions:
+  #     id-token: write
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #     - name: Move wheels to dist
+  #       run: |
+  #         mv wheels-*/*.whl dist/
+  #     - name: Publish to PyPI
+  #       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -12,20 +12,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: "true"
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install build
-
       - name: Build sdist
         run: python -m build --sdist --outdir dist
-
       - uses: actions/upload-artifact@v4
         with:
           name: dist-source
@@ -41,18 +37,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: "true"
-
-      - uses: actions/setup-python@v5
-        name: Set up Python
-        with:
-          python-version: "3.11"
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel>=2
-
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir dist
-
+        uses: pypa/cibuildwheel@v2.21.1
+        with:
+          output-dir: dist
       - uses: actions/upload-artifact@v4
         with:
           name: dist-${{ matrix.os }}

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -3,7 +3,6 @@ name: Build and publish to PyPI
 on:
   release:
     types: [created]
-  pull_request:  # for testing
 
 jobs:
   build-sdist:
@@ -47,18 +46,18 @@ jobs:
           name: dist-${{ matrix.os }}
           path: dist
 
-  # publish-to-pypi:
-  #   needs: [build-sdist, build-wheels]
-  #   runs-on: ubuntu-latest
-  #   environment:
-  #     name: pypi
-  #     url: https://pypi.org/p/ms2pip
-  #   permissions:
-  #     id-token: write
-  #   steps:
-  #     - uses: actions/download-artifact@v4
-  #     - name: Move wheels to dist
-  #       run: |
-  #         mv wheels-*/*.whl dist/
-  #     - name: Publish to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
+  publish-to-pypi:
+    needs: [build-sdist, build-wheels]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ms2pip
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Move wheels to dist
+        run: |
+          mv wheels-*/*.whl dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "3.8"
+    python: "3.11"
   jobs:
     post_checkout:
       # Download and uncompress the binary

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,7 +6,7 @@ Pip package
 .. image:: https://flat.badgen.net/badge/install%20with/pip/green
    :target: https://pypi.org/project/ms2pip/
 
-With Python 3.8 or higher, run:
+With Python 3.9 or higher, run:
 
 .. code-block:: bash
 

--- a/ms2pip/search_space.py
+++ b/ms2pip/search_space.py
@@ -160,7 +160,7 @@ class ProteomeSearchSpace(BaseModel):
     min_length: int = 8
     max_length: int = 30
     min_precursor_mz: Optional[float] = 0
-    max_precursor_mz: Optional[float] = np.Inf
+    max_precursor_mz: Optional[float] = np.inf
     cleavage_rule: str = "trypsin"
     missed_cleavages: int = 2
     semi_specific: bool = False
@@ -184,7 +184,7 @@ class ProteomeSearchSpace(BaseModel):
         min_precursor_mz
             Minimum precursor m/z for peptides. Default is 0.
         max_precursor_mz
-            Maximum precursor m/z for peptides. Default is np.Inf.
+            Maximum precursor m/z for peptides. Default is np.inf.
         cleavage_rule
             Cleavage rule for peptide digestion. Default is "trypsin".
         missed_cleavages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Development Status :: 5 - Production/Stable",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.25,<3",
     "pandas>=1,<3",
@@ -83,15 +83,15 @@ include = ["ms2pip*"]
 
 [tool.black]
 line-length = 99
-target-version = ['py38']
+target-version = ['py39']
 
 [tool.ruff]
 line-length = 99
-target-version = 'py38'
+target-version = 'py39'
 
 [tool.cibuildwheel]
 build = "cp3*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64"
-skip = "cp36-* cp37-* cp312-*"                                    # EOL / no Numpy wheels available yet for Python 3.12
+skip = "cp36-* cp37-* cp38-*"
 manylinux-x86_64-image = "manylinux2014"
 # test-command = "pytest {package}/tests"
 test-command = "ms2pip --help"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ target-version = 'py39'
 [tool.cibuildwheel]
 build = "cp3*-manylinux_x86_64 cp3*-musllinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64"
 skip = "cp36-* cp37-* cp38-*"
-before-test = "cd {project} && rm ms2pip"  # Remove the ms2pip dir to avoid conflicts with the built wheel
+before-test = "cd {project} && rm -r ms2pip"  # Remove the ms2pip dir to avoid conflicts with the built wheel
 test-requires = "pytest"
 test-command = "pytest {package}/tests && ms2pip --help"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ target-version = 'py39'
 
 [tool.cibuildwheel]
 build = "cp3*-manylinux_x86_64 cp3*-musllinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64"
-skip = "cp36-* cp37-* cp38-*"
+skip = "cp36-* cp37-* cp38-* cp313-*"                                                                     # No ms2rescore-rs for 3.13
 test-command = "ms2pip --help"
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ target-version = 'py39'
 [tool.cibuildwheel]
 build = "cp3*-manylinux_x86_64 cp3*-musllinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64"
 skip = "cp36-* cp37-* cp38-*"
+before-test = "cd {project} && rm ms2pip"  # Remove the ms2pip dir to avoid conflicts with the built wheel
 test-requires = "pytest"
 test-command = "pytest {package}/tests && ms2pip --help"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,14 +33,14 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy>=1.16,<2",
-    "pandas>=1,<2",
+    "numpy>=1.25,<3",
+    "pandas>=1,<3",
     "pyarrow",
     "pyteomics>=3.5,<5",
     "tomlkit>=0.5,<1",
     "sqlalchemy>=1.3,<2",
     "click>=7,<9",
-    "xgboost>=1.3,<2",
+    "xgboost>=1.3",
     "lxml>=4",
     "rich>=13",
     "pydantic>=2",
@@ -75,7 +75,7 @@ publication = "https://doi.org/10.1093/nar/gkad335/"
 ms2pip = "ms2pip.__main__:main"
 
 [build-system]
-requires = ["setuptools", "cython", "oldest-supported-numpy"]
+requires = ["setuptools", "cython", "numpy>=2.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,11 +90,9 @@ line-length = 99
 target-version = 'py39'
 
 [tool.cibuildwheel]
-build = "cp3*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64"
+build = "cp3*-manylinux_x86_64 cp3*-musllinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64"
 skip = "cp36-* cp37-* cp38-*"
-manylinux-x86_64-image = "manylinux2014"
-# test-command = "pytest {package}/tests"
-test-command = "ms2pip --help"
+test-command = "pytest {package}/tests && ms2pip --help"
 
 [tool.cibuildwheel.macos]
 before-all = "brew install libomp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ target-version = 'py39'
 [tool.cibuildwheel]
 build = "cp3*-manylinux_x86_64 cp3*-musllinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64"
 skip = "cp36-* cp37-* cp38-*"
+test-requires = "pytest"
 test-command = "pytest {package}/tests && ms2pip --help"
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,9 +92,7 @@ target-version = 'py39'
 [tool.cibuildwheel]
 build = "cp3*-manylinux_x86_64 cp3*-musllinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64"
 skip = "cp36-* cp37-* cp38-*"
-before-test = "cd {project} && rm -r ms2pip"  # Remove the ms2pip dir to avoid conflicts with the built wheel
-test-requires = "pytest"
-test-command = "pytest {package}/tests && ms2pip --help"
+test-command = "ms2pip --help"
 
 [tool.cibuildwheel.macos]
 before-all = "brew install libomp"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,9 @@
+import numpy as np
+from psm_utils import PSM, Peptidoform
 import pandas as pd
 
-from ms2pip.core import get_training_data
+from ms2pip.core import get_training_data, predict_single
+from ms2pip.result import ProcessingResult
 
 
 def _test_get_training_data():
@@ -13,3 +16,33 @@ def _test_get_training_data():
         processes=1
     )
     pd.testing.assert_frame_equal(expected_df, output_df)
+
+def test_predict_single():
+    pep = Peptidoform("ACDE/2")
+    result = predict_single(pep)
+
+    expected = ProcessingResult(
+        psm_index=0,
+        psm=PSM(peptidoform=pep, spectrum_id=0),
+        theoretical_mz={
+            "b": np.array([72.04435, 175.05354, 290.08047], dtype=np.float32),
+            "y": np.array([148.0604, 263.0873, 366.0965], dtype=np.float32),
+        },
+        predicted_intensity={
+            "b": np.array([-9.14031, -7.6102686, -7.746709], dtype=np.float32),
+            "y": np.array([-5.8988147, -5.811797, -7.069088], dtype=np.float32),
+        },
+        observed_intensity=None,
+        correlation=None,
+        feature_vectors=None,
+    )
+
+    assert result.psm_index == expected.psm_index
+    assert result.psm == expected.psm
+    np.testing.assert_array_almost_equal(result.theoretical_mz["b"], expected.theoretical_mz["b"])
+    np.testing.assert_array_almost_equal(result.theoretical_mz["y"], expected.theoretical_mz["y"])
+    np.testing.assert_array_almost_equal(result.predicted_intensity["b"], expected.predicted_intensity["b"])
+    np.testing.assert_array_almost_equal(result.predicted_intensity["y"], expected.predicted_intensity["y"])
+    assert result.observed_intensity == expected.observed_intensity
+    assert result.correlation == expected.correlation
+    assert result.feature_vectors == expected.feature_vectors


### PR DESCRIPTION
### Added
- CI: Add integration test for `predict-single`
- Added support for Python 3.12
- Added support for Numpy v2, and newer Pandas and XGBoost versions

### Removed
- Removed support for Python 3.8 (EOL)