### PR TITLE
Output IM instead of CCS in predict_library

### DIFF
--- a/ms2pip/_utils/ion_mobility.py
+++ b/ms2pip/_utils/ion_mobility.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class IonMobility:
-    """Predict ion mobility using IM²Deep."""
+    """Predict ion mobility using IM2Deep."""
 
     def __init__(self, processes=1) -> None:
         # Lazy import to avoid loading loading heavy dependencies when not needed
@@ -27,6 +27,6 @@ class IonMobility:
         """Add ion mobility predictions to the PSMList."""
         logger.info("Predicting ion mobility...")
         predictions: pd.Series = self.predict_fn(
-            psm_list, write_output=False, n_jobs=self.processes
+            psm_list, write_output=False, n_jobs=self.processes, ion_mobility=True
         )
         psm_list["ion_mobility"] = predictions.values


### PR DESCRIPTION
Currently, CCS is outputted in the spectral library if ion mobility prediction is enabled, while it makes more sense to output IM directly. IM2Deep v0.3.1 allows direct conversion of predicted CCS values into IM. Passing the ion_mobility=True argument to the IonMobility predict_fn will do the job.

---

### Changed

- Return ion mobility instead of collisional cross section from IM2Deep