### PR TITLE
Remove musllinux builds (no ms2rescore-rs builds)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,8 @@ line-length = 99
 target-version = 'py39'
 
 [tool.cibuildwheel]
-build = "cp3*-manylinux_x86_64 cp3*-musllinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64"
-skip = "cp36-* cp37-* cp38-* cp313-*"                                                                     # No ms2rescore-rs for 3.13
+build = "cp3*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64"
+skip = "cp36-* cp37-* cp38-* cp313-*"                                               # No ms2rescore-rs for 3.13
 test-command = "ms2pip --help"
 
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
### Removed

- Removed musllinux builds