### PR TITLE
Fix readthedocs (adding sphinx configuration key)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -32,3 +32,4 @@ python:
 
 sphinx:
   builder: dirhtml
+  configuration: docs/source/conf.py


### PR DESCRIPTION
### Fixed
- Docs: Add newly required sphinx configuration key