### PR TITLE
Improve runtime for predict_library by running DeepLC and IM2Deep predictions only once

### DIFF
--- a/ms2pip/core.py
+++ b/ms2pip/core.py
@@ -112,15 +112,15 @@ def predict_batch(
         psms = PSMList(psm_list=psms)
     psm_list = read_psms(psms, filetype=psm_filetype)
 
-    # if add_retention_time:
-    #     logger.info("Adding retention time predictions")
-    #     rt_predictor = RetentionTime(processes=processes)
-    #     rt_predictor.add_rt_predictions(psm_list)
+    if add_retention_time:
+        logger.info("Adding retention time predictions")
+        rt_predictor = RetentionTime(processes=processes)
+        rt_predictor.add_rt_predictions(psm_list)
 
-    # if add_ion_mobility:
-    #     logger.info("Adding ion mobility predictions")
-    #     im_predictor = IonMobility(processes=processes)
-    #     im_predictor.add_im_predictions(psm_list)
+    if add_ion_mobility:
+        logger.info("Adding ion mobility predictions")
+        im_predictor = IonMobility(processes=processes)
+        im_predictor.add_im_predictions(psm_list)
 
     with Encoder.from_psm_list(psm_list) as encoder:
         ms2pip_parallelized = _Parallelized(
@@ -217,8 +217,6 @@ def predict_library(
         logging.disable(logging.CRITICAL)
         yield predict_batch(
             batch,
-            add_retention_time=add_retention_time,
-            add_ion_mobility=add_ion_mobility,
             model=model,
             model_dir=model_dir,
             processes=processes,

--- a/ms2pip/core.py
+++ b/ms2pip/core.py
@@ -112,15 +112,15 @@ def predict_batch(
         psms = PSMList(psm_list=psms)
     psm_list = read_psms(psms, filetype=psm_filetype)
 
-    if add_retention_time:
-        logger.info("Adding retention time predictions")
-        rt_predictor = RetentionTime(processes=processes)
-        rt_predictor.add_rt_predictions(psm_list)
+    # if add_retention_time:
+    #     logger.info("Adding retention time predictions")
+    #     rt_predictor = RetentionTime(processes=processes)
+    #     rt_predictor.add_rt_predictions(psm_list)
 
-    if add_ion_mobility:
-        logger.info("Adding ion mobility predictions")
-        im_predictor = IonMobility(processes=processes)
-        im_predictor.add_im_predictions(psm_list)
+    # if add_ion_mobility:
+    #     logger.info("Adding ion mobility predictions")
+    #     im_predictor = IonMobility(processes=processes)
+    #     im_predictor.add_im_predictions(psm_list)
 
     with Encoder.from_psm_list(psm_list) as encoder:
         ms2pip_parallelized = _Parallelized(
@@ -189,16 +189,34 @@ def predict_library(
         raise ValueError("Either `fasta_file` or `config` must be provided.")
 
     search_space = ProteomeSearchSpace.from_any(config)
-    search_space.build()
+    search_space.build(processes=processes)
+
+    # Convert to PSMList
+    psm_list = search_space.to_psm_list()
+
+    # Filter PSMs by mz
+    # TODO: Parallelize this step?
+    psm_list_filtered = search_space.filter_psms_by_mz(psm_list)
+
+    # Add retention time and ion mobility predictions
+    if add_retention_time:
+        logger.info("Adding retention time predictions...")
+        rt_predictor = RetentionTime(processes=processes)
+        rt_predictor.add_rt_predictions(psm_list_filtered)
+    if add_ion_mobility:
+        logger.info("Adding ion mobility predictions...")
+        im_predictor = IonMobility(processes=processes)
+        im_predictor.add_im_predictions(psm_list_filtered)
 
     for batch in track(
-        _into_batches(search_space, batch_size=batch_size),
+        _into_batches(psm_list_filtered, batch_size=batch_size),
         description="Predicting spectra...",
         total=ceil(len(search_space) / batch_size),
     ):
+
         logging.disable(logging.CRITICAL)
         yield predict_batch(
-            search_space.filter_psms_by_mz(PSMList(psm_list=list(batch))),
+            batch,
             add_retention_time=add_retention_time,
             add_ion_mobility=add_ion_mobility,
             model=model,

--- a/ms2pip/search_space.py
+++ b/ms2pip/search_space.py
@@ -265,7 +265,9 @@ class ProteomeSearchSpace(BaseModel):
             Number of processes to use for parallelization.
 
         """
-        processes = processes if processes else multiprocessing.cpu_count()
+        processes = (
+            processes if processes else multiprocessing.cpu_count()
+        )  # Always ignored because of the default value
         self._digest_fasta(processes)
         self._remove_redundancy()
         self._add_modifications(processes)
@@ -307,6 +309,10 @@ class ProteomeSearchSpace(BaseModel):
                 if self.min_precursor_mz <= psm.peptidoform.theoretical_mz <= self.max_precursor_mz
             ]
         )
+
+    def to_psm_list(self) -> PSMList:
+        """Convert search space to PSMList."""
+        return PSMList(psm_list=list(self))
 
     def _digest_fasta(self, processes: int = 1):
         """Digest FASTA file to peptides and populate search space."""


### PR DESCRIPTION
Key changes:

### Changes to `predict_library` function:

* Added conversion of search space to `PSMList` and filtering of PSMs by mz in `predict_library` function (`ms2pip/core.py`).
* Moved steps to add retention time and ion mobility predictions if specified (`ms2pip/core.py`).

### Improvements in `search_space` handling:

* Introduced `to_psm_list` method to convert search space to `PSMList` (`ms2pip/search_space.py`). 
* Modified `build` method to ensure the number of processes is correctly set and used for parallelization (`ms2pip/search_space.py`).

Timing of runs on `releases` and this branch, on a small fasta subset of human proteome (semi-tryptic) (~240.000 PSMs, so 3 batches):
`releases`: 3099.83s user 1460.12s system 1312% cpu 5:47.51 total
this branch: 2405.46s user 596.67s system 1334% cpu 3:44.90 total
