### PR TITLE
CI: Don't build dependencies like pyarrow from source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,5 +93,8 @@ build = "cp3*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm
 skip = "cp36-* cp37-* cp38-*"
 test-command = "ms2pip --help"
 
+# Prevent building from source for packages with complex C/C++ dependencies
+environment = { PIP_ONLY_BINARY = "pyarrow,pandas,numpy,lxml,xgboost" }
+
 [tool.cibuildwheel.macos]
 before-all = "brew install libomp"


### PR DESCRIPTION
### Fixed
- `CI`: Don't build dependencies like pyarrow from source. This can result in failed build workflows.