### PR TITLE
Prefer genesis for model downloads, fall back to Zenodo

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14] # macos-13 for intel, macos-14 for apple silicon
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel] # macos-latest for ARM, macos-15-intel for x86_64; see https://github.com/actions/runner-images/issues/13046
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ms2pip/__init__.py
+++ b/ms2pip/__init__.py
@@ -1,7 +1,7 @@
 # isort: skip_file
 """MS2PIP: Accurate and versatile peptide fragmentation spectrum prediction."""
 
-__version__ = "4.1.1"
+__version__ = "4.1.2"
 
 from warnings import filterwarnings
 

--- a/ms2pip/_utils/xgb_models.py
+++ b/ms2pip/_utils/xgb_models.py
@@ -96,7 +96,11 @@ def _download_model(model, model_hash, model_dir):
     filename = os.path.join(model_dir, model)
 
     logger.info(f"Downloading {model} to {filename}...")
-    urllib.request.urlretrieve(f"https://zenodo.org/records/13270668/files/{model}", filename)
+    try:
+        urllib.request.urlretrieve(f"https://genesis.ugent.be/uvpublicdata/ms2pip/{model}", filename)
+    except Exception:
+        logger.warning("Falling back to Zenodo for model downloads.")
+        urllib.request.urlretrieve(f"https://zenodo.org/records/13270668/files/{model}", filename)
     if not _check_model_integrity(filename, model_hash):
         raise InvalidXGBoostModelError()
 


### PR DESCRIPTION
### Fixed
- Prefer (faster) Genesis for model downloads, with a fall back to Zenodo
- CI: Update build runners for macOS (see https://github.com/actions/runner-images/issues/13046)
