### PR TITLE
fix logging for spectral library prediction

### DIFF
--- a/ms2pip/__main__.py
+++ b/ms2pip/__main__.py
@@ -52,7 +52,7 @@ def cli(*args, **kwargs):
         datefmt="%Y-%m-%d %H:%M:%S",
         level=LOGGING_LEVELS[kwargs["logging_level"]],
         handlers=[
-            RichHandler(rich_tracebacks=True, console=console, show_level=True, show_path=False)
+            RichHandler(rich_tracebacks=True, show_level=True, show_path=False)
         ],
     )
     console.print(build_credits())

--- a/ms2pip/__main__.py
+++ b/ms2pip/__main__.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from typing import Optional
 
 import click
+import rich
 from psm_utils.io import READERS
-from rich.console import Console
 from rich.logging import RichHandler
 from werkzeug.utils import secure_filename
 
@@ -17,7 +17,6 @@ from ms2pip.plot import spectrum_to_png
 from ms2pip.result import write_correlations
 from ms2pip.spectrum_output import SUPPORTED_FORMATS, write_spectra
 
-console = Console()
 logger = logging.getLogger(__name__)
 
 LOGGING_LEVELS = {
@@ -55,7 +54,7 @@ def cli(*args, **kwargs):
             RichHandler(rich_tracebacks=True, show_level=True, show_path=False)
         ],
     )
-    console.print(build_credits())
+    rich.print(build_credits())
 
 
 @cli.command(help=ms2pip.core.predict_single.__doc__)
@@ -78,7 +77,7 @@ def predict_single(*args, **kwargs):
     predicted_spectrum, _ = result.as_spectra()
 
     # Write output
-    console.print(build_prediction_table(predicted_spectrum))
+    rich.print(build_prediction_table(predicted_spectrum))
     write_spectra(output_name, [result], output_format)
     if plot:
         spectrum_to_png(predicted_spectrum, output_name)

--- a/ms2pip/core.py
+++ b/ms2pip/core.py
@@ -196,7 +196,6 @@ def predict_library(
         description="Predicting spectra...",
         total=ceil(len(search_space) / batch_size),
     ):
-        logging.disable(logging.CRITICAL)
         yield predict_batch(
             search_space.filter_psms_by_mz(PSMList(psm_list=list(batch))),
             add_retention_time=add_retention_time,
@@ -205,7 +204,6 @@ def predict_library(
             model_dir=model_dir,
             processes=processes,
         )
-        logging.disable(logging.NOTSET)
 
 
 def correlate(


### PR DESCRIPTION
- drop disabling the logging during spectral library prediction
- fix formatting of logging output by dropping the console argument, making sure logging and progress tracking use the same global console object
- drop our console object and use `rich.print` instead