### PR TITLE
Refactor/cleanup python internals

### DIFF
--- a/ms2pip/__main__.py
+++ b/ms2pip/__main__.py
@@ -42,13 +42,18 @@ def _infer_output_name(
 
 
 @click.group()
-@click.option("--logging-level", "-l", type=click.Choice(LOGGING_LEVELS.keys()), default="INFO")
+@click.option(
+    "--logging-level",
+    "-l",
+    type=click.Choice(LOGGING_LEVELS.keys(), case_sensitive=False),
+    default="INFO",
+)
 @click.version_option(version=__version__)
 def cli(*args, **kwargs):
     logging.basicConfig(
         format="%(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=LOGGING_LEVELS[kwargs["logging_level"]],
+        level=LOGGING_LEVELS[kwargs["logging_level"].upper()],
         handlers=[RichHandler(rich_tracebacks=True, show_level=True, show_path=False)],
     )
     rich.print(build_credits())

--- a/ms2pip/_spectrum_processing.py
+++ b/ms2pip/_spectrum_processing.py
@@ -27,20 +27,13 @@ from ms2pip.spectrum import ObservedSpectrum
 logger = logging.getLogger(__name__)
 
 
-def _annotations_to_tuples(peak_annotations: list) -> list[list[tuple]]:
-    """Convert FragmentAnnotation lists to plain (series, position, charge) tuples."""
-    return [
-        [(a.series, a.position, a.charge) for a in peak_anns] for peak_anns in peak_annotations
-    ]
-
-
 class MatchedSpectrum(NamedTuple):
-    """A PSM matched to its preprocessed observed spectrum and peak annotations."""
+    """A PSM matched to its preprocessed observed spectrum and annotated spectrum."""
 
     psm_index: int
     psm: PSM
     spectrum: ObservedSpectrum
-    peak_annotations: list
+    annotated_spectrum: AnnotatedMS2Spectrum
 
 
 def _read_raw_spectra(spectrum_file: str) -> Generator[MS2Spectrum, None, None]:
@@ -115,11 +108,11 @@ def annotate_spectrum(
     model: str,
     ms2_tolerance: float,
     ms2_tolerance_mode: str,
-) -> list[list[tuple]]:
+) -> AnnotatedMS2Spectrum:
     """
     Annotate an ObservedSpectrum using ms2rescore-rs.
 
-    Returns peak annotations as plain Python lists of ``(series, position, charge)`` tuples.
+    Returns the AnnotatedMS2Spectrum object from ms2rescore-rs.
     """
     ms2_spectrum = MS2Spectrum(
         identifier=spectrum.identifier or "",
@@ -133,72 +126,16 @@ def annotate_spectrum(
     )
     frag_model = MODELS[model]["fragmentation"]
     proforma = proforma_to_mass_shift(psm.peptidoform)
-    seq_len = len(psm.peptidoform.parsed_sequence)
 
     annotated = annotate_ms2_spectra(
         spectra=[ms2_spectrum],
         proformas=[proforma],
-        seq_lens=[seq_len],
         fragmentation_model=frag_model,
         mass_mode="monoisotopic",
         tolerance_value=float(ms2_tolerance),
         tolerance_mode=ms2_tolerance_mode.lower(),
     )
-    return _annotations_to_tuples(annotated[0].peak_annotations)
-
-
-def targets_from_annotations(
-    peak_annotations: list,
-    intensity: np.ndarray,
-    ion_types: list[str],
-    seq_len: int,
-) -> dict[str, np.ndarray]:
-    """
-    Extract observed intensity targets from peak annotations.
-
-    Converts per-peak fragment annotations into per-ion-type intensity arrays.
-
-    Parameters
-    ----------
-    peak_annotations
-        Per-peak annotations. Each element is a list of annotations for that peak.
-        Annotations can be :py:class:`ms2rescore_rs.FragmentAnnotation` objects or
-        ``(series, position, charge)`` tuples.
-    intensity
-        Preprocessed intensity array (TIC-normalized, log2-transformed).
-    ion_types
-        Ion types to extract, e.g. ``["b", "y"]`` or ``["b", "y", "b2", "y2"]``.
-    seq_len
-        Length of the peptide sequence (number of amino acids).
-
-    Returns
-    -------
-    targets
-        Dict mapping ion type to intensity array of length ``seq_len - 1``.
-
-    """
-    n_ions = seq_len - 1
-    floor_value = np.float32(np.log2(0.001))
-    targets = {ion: np.full(n_ions, floor_value, dtype=np.float32) for ion in ion_types}
-
-    for peak_idx, peak_anns in enumerate(peak_annotations):
-        for ann in peak_anns:
-            if isinstance(ann, tuple):
-                series, position, charge = ann
-            else:
-                series, position, charge = ann.series, ann.position, ann.charge
-
-            ion_key = series if charge == 1 else f"{series}{charge}"
-
-            if ion_key not in targets:
-                continue
-
-            pos = position - 1
-            if 0 <= pos < n_ions:
-                if intensity[peak_idx] > targets[ion_key][pos]:
-                    targets[ion_key][pos] = intensity[peak_idx]
-
-    return targets
+    return annotated[0]
 
 
 def _load_and_match_spectra(
@@ -253,14 +190,12 @@ def _load_and_match_spectra(
     logger.debug("Annotating %d matched spectra...", len(matched_raw))
     batch_spectra = []
     batch_proformas = []
-    batch_seq_lens = []
     batch_indices = []  # (matched_raw_idx, psm_within_spectrum_idx)
 
     for raw_idx, (_, spectrum, psm_pairs) in enumerate(matched_raw):
         for psm_idx, (_, psm) in enumerate(psm_pairs):
             batch_spectra.append(spectrum)
             batch_proformas.append(proforma_to_mass_shift(psm.peptidoform))
-            batch_seq_lens.append(len(psm.peptidoform.parsed_sequence))
             batch_indices.append((raw_idx, psm_idx))
 
     frag_model = MODELS[model]["fragmentation"]
@@ -268,7 +203,6 @@ def _load_and_match_spectra(
     annotated_spectra = annotate_ms2_spectra(
         spectra=batch_spectra,
         proformas=batch_proformas,
-        seq_lens=batch_seq_lens,
         fragmentation_model=frag_model,
         mass_mode="monoisotopic",
         tolerance_value=float(ms2_tolerance),
@@ -289,10 +223,8 @@ def _load_and_match_spectra(
             _preprocess_spectrum(obs, model)
             preprocessed_cache[spec_id] = obs
 
-        peak_annotations = _annotations_to_tuples(annotated_spectra[batch_idx].peak_annotations)
-
         results.append(
-            MatchedSpectrum(psm_index, psm, preprocessed_cache[spec_id], peak_annotations)
+            MatchedSpectrum(psm_index, psm, preprocessed_cache[spec_id], annotated_spectra[batch_idx])
         )
 
     return results
@@ -316,7 +248,9 @@ def _preloaded_to_annotations(
     # Convert to ObservedSpectrum and preprocess; store raw spectra and annotations
     preloaded_spectra: dict[str, ObservedSpectrum] = {}
     raw_spectra: dict[str, MS2Spectrum] = {}
-    preloaded_annotations: dict[str, list] | None = {} if spectra_are_annotated else None
+    preloaded_annotated: dict[str, AnnotatedMS2Spectrum] | None = (
+        {} if spectra_are_annotated else None
+    )
     for psm in psm_list:
         spec_id = str(psm.spectrum_id)
         if spec_id in preloaded_spectra:
@@ -329,8 +263,8 @@ def _preloaded_to_annotations(
         raw_spectra[spec_id] = spectrum  # keep original for annotation
         if spectra_are_annotated:
             assert isinstance(spectrum, AnnotatedMS2Spectrum)
-            assert preloaded_annotations is not None
-            preloaded_annotations[spec_id] = _annotations_to_tuples(spectrum.peak_annotations)
+            assert preloaded_annotated is not None
+            preloaded_annotated[spec_id] = spectrum
 
     # Build MatchedSpectrum list
     psm_spectrum_annotations: list[MatchedSpectrum] = []
@@ -341,12 +275,15 @@ def _preloaded_to_annotations(
         obs_spectrum = preloaded_spectra.get(spec_id)
         if obs_spectrum is None:
             continue
-        if preloaded_annotations is not None and spec_id in preloaded_annotations:
+        if preloaded_annotated is not None and spec_id in preloaded_annotated:
             psm_spectrum_annotations.append(
-                MatchedSpectrum(i, psm, obs_spectrum, preloaded_annotations[spec_id])
+                MatchedSpectrum(i, psm, obs_spectrum, preloaded_annotated[spec_id])
             )
         else:
-            psm_spectrum_annotations.append(MatchedSpectrum(i, psm, obs_spectrum, []))
+            # Placeholder -- will be replaced after batch annotation below
+            psm_spectrum_annotations.append(
+                MatchedSpectrum(i, psm, obs_spectrum, None)  # type: ignore[arg-type]
+            )
             needs_annotation.append(len(psm_spectrum_annotations) - 1)
 
     # Batch annotate any unannotated spectra using original MS2Spectrum objects
@@ -354,17 +291,14 @@ def _preloaded_to_annotations(
         frag_model = MODELS[model]["fragmentation"]
         batch_spectra = []
         batch_proformas = []
-        batch_seq_lens = []
         for idx in needs_annotation:
             m = psm_spectrum_annotations[idx]
             batch_spectra.append(raw_spectra[str(m.psm.spectrum_id)])
             batch_proformas.append(proforma_to_mass_shift(m.psm.peptidoform))
-            batch_seq_lens.append(len(m.psm.peptidoform.parsed_sequence))
 
         annotated = annotate_ms2_spectra(
             spectra=batch_spectra,
             proformas=batch_proformas,
-            seq_lens=batch_seq_lens,
             fragmentation_model=frag_model,
             mass_mode="monoisotopic",
             tolerance_value=float(ms2_tolerance),
@@ -373,8 +307,7 @@ def _preloaded_to_annotations(
 
         for j, idx in enumerate(needs_annotation):
             m = psm_spectrum_annotations[idx]
-            peak_anns = _annotations_to_tuples(annotated[j].peak_annotations)
-            psm_spectrum_annotations[idx] = m._replace(peak_annotations=peak_anns)
+            psm_spectrum_annotations[idx] = m._replace(annotated_spectrum=annotated[j])
 
     return psm_spectrum_annotations
 

--- a/ms2pip/_spectrum_processing.py
+++ b/ms2pip/_spectrum_processing.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import NamedTuple
 
 import numpy as np
-from psm_utils import PSM, PSMList, Peptidoform
 from ms2rescore_rs import (
     AnnotatedMS2Spectrum,  # type: ignore[ty:unresolved-import]
     MS2Spectrum,  # type: ignore[ty:unresolved-import]
@@ -19,12 +18,20 @@ from ms2rescore_rs import (
     annotate_ms2_spectra,  # type: ignore[ty:unresolved-import]
     get_ms2_spectra,  # type: ignore[ty:unresolved-import]
 )
+from psm_utils import PSM, Peptidoform, PSMList
 
 import ms2pip.exceptions as exceptions
 from ms2pip.constants import MODELS
 from ms2pip.spectrum import ObservedSpectrum
 
 logger = logging.getLogger(__name__)
+
+
+def _annotations_to_tuples(peak_annotations: list) -> list[list[tuple]]:
+    """Convert FragmentAnnotation lists to plain (series, position, charge) tuples."""
+    return [
+        [(a.series, a.position, a.charge) for a in peak_anns] for peak_anns in peak_annotations
+    ]
 
 
 class MatchedSpectrum(NamedTuple):
@@ -137,10 +144,7 @@ def annotate_spectrum(
         tolerance_value=float(ms2_tolerance),
         tolerance_mode=ms2_tolerance_mode.lower(),
     )
-    return [
-        [(a.series, a.position, a.charge) for a in peak_anns]
-        for peak_anns in annotated[0].peak_annotations
-    ]
+    return _annotations_to_tuples(annotated[0].peak_annotations)
 
 
 def targets_from_annotations(
@@ -224,6 +228,7 @@ def _load_and_match_spectra(
         psms_by_specid[str(psm.spectrum_id)].append((i, psm))
 
     # Step 1: Read raw spectra and match to PSMs (no conversion yet)
+    logger.info("Reading spectra from file...")
     matched_raw: list[tuple[str, MS2Spectrum, list[tuple[int, PSM]]]] = []
     for spectrum in _read_raw_spectra(str(spectrum_file)):
         match = spectrum_id_regex.search(str(spectrum.identifier))
@@ -245,6 +250,7 @@ def _load_and_match_spectra(
         return []
 
     # Step 2: Batch annotate all matched spectra (single Rust call, Rayon-parallelized)
+    logger.debug("Annotating %d matched spectra...", len(matched_raw))
     batch_spectra = []
     batch_proformas = []
     batch_seq_lens = []
@@ -258,6 +264,7 @@ def _load_and_match_spectra(
             batch_indices.append((raw_idx, psm_idx))
 
     frag_model = MODELS[model]["fragmentation"]
+    logger.debug("Starting annotation...")
     annotated_spectra = annotate_ms2_spectra(
         spectra=batch_spectra,
         proformas=batch_proformas,
@@ -267,6 +274,7 @@ def _load_and_match_spectra(
         tolerance_value=float(ms2_tolerance),
         tolerance_mode=ms2_tolerance_mode.lower(),
     )
+    logger.debug("Annotation complete.")
 
     # Step 3: Convert to ObservedSpectrum, preprocess, and assemble results
     preprocessed_cache: dict[str, ObservedSpectrum] = {}
@@ -281,12 +289,11 @@ def _load_and_match_spectra(
             _preprocess_spectrum(obs, model)
             preprocessed_cache[spec_id] = obs
 
-        peak_annotations = [
-            [(a.series, a.position, a.charge) for a in peak_anns]
-            for peak_anns in annotated_spectra[batch_idx].peak_annotations
-        ]
+        peak_annotations = _annotations_to_tuples(annotated_spectra[batch_idx].peak_annotations)
 
-        results.append(MatchedSpectrum(psm_index, psm, preprocessed_cache[spec_id], peak_annotations))
+        results.append(
+            MatchedSpectrum(psm_index, psm, preprocessed_cache[spec_id], peak_annotations)
+        )
 
     return results
 
@@ -323,10 +330,7 @@ def _preloaded_to_annotations(
         if spectra_are_annotated:
             assert isinstance(spectrum, AnnotatedMS2Spectrum)
             assert preloaded_annotations is not None
-            preloaded_annotations[spec_id] = [
-                [(a.series, a.position, a.charge) for a in peak_anns]
-                for peak_anns in spectrum.peak_annotations
-            ]
+            preloaded_annotations[spec_id] = _annotations_to_tuples(spectrum.peak_annotations)
 
     # Build MatchedSpectrum list
     psm_spectrum_annotations: list[MatchedSpectrum] = []
@@ -369,10 +373,7 @@ def _preloaded_to_annotations(
 
         for j, idx in enumerate(needs_annotation):
             m = psm_spectrum_annotations[idx]
-            peak_anns = [
-                [(a.series, a.position, a.charge) for a in anns]
-                for anns in annotated[j].peak_annotations
-            ]
+            peak_anns = _annotations_to_tuples(annotated[j].peak_annotations)
             psm_spectrum_annotations[idx] = m._replace(peak_annotations=peak_anns)
 
     return psm_spectrum_annotations
@@ -397,9 +398,7 @@ def resolve_spectra(
     ]
     if all(has_spectrum):
         if spectrum_file is not None:
-            logger.warning(
-                "PSMs already have preloaded spectra; `spectrum_file` will be ignored."
-            )
+            logger.warning("PSMs already have preloaded spectra; `spectrum_file` will be ignored.")
         matched = _preloaded_to_annotations(psm_list, model, ms2_tolerance, ms2_tolerance_mode)
     elif not any(has_spectrum):
         if spectrum_file is None:

--- a/ms2pip/_utils/xgb_models.py
+++ b/ms2pip/_utils/xgb_models.py
@@ -15,7 +15,7 @@ from ms2pip.constants import MODELS
 
 logger = logging.getLogger(__name__)
 
-_MAX_PREDICTION_THREADS = 16
+_MAX_PREDICTION_THREADS = 32
 
 
 def validate_model(model: str, model_dir: str | Path | None = None) -> Path:
@@ -77,11 +77,10 @@ def load_xgb_models(
         Number of threads for XGBoost prediction. Capped internally.
 
     """
-    # nthread = min(
-    #     processes if processes is not None else (os.cpu_count() or 1),
-    #     _MAX_PREDICTION_THREADS,
-    # )
-    nthread = processes if processes is not None else (os.cpu_count() or 1)
+    nthread = min(
+        processes if processes is not None else (os.cpu_count() or 1),
+        _MAX_PREDICTION_THREADS,
+    )
     return _initialize_xgb_models(model_params["xgboost_model_files"], model_dir, nthread)
 
 

--- a/ms2pip/_utils/xgb_models.py
+++ b/ms2pip/_utils/xgb_models.py
@@ -77,10 +77,11 @@ def load_xgb_models(
         Number of threads for XGBoost prediction. Capped internally.
 
     """
-    nthread = min(
-        processes if processes is not None else (os.cpu_count() or 1),
-        _MAX_PREDICTION_THREADS,
-    )
+    # nthread = min(
+    #     processes if processes is not None else (os.cpu_count() or 1),
+    #     _MAX_PREDICTION_THREADS,
+    # )
+    nthread = processes if processes is not None else (os.cpu_count() or 1)
     return _initialize_xgb_models(model_params["xgboost_model_files"], model_dir, nthread)
 
 

--- a/ms2pip/core.py
+++ b/ms2pip/core.py
@@ -85,11 +85,11 @@ def _predict_batch_internal(
 
     _set_rayon_threads(processes)
 
-    # Batch compute theoretical m/z (single Rust call, Rayon-parallelized)
+    # Batch compute theoretical m/z
     logger.debug("Computing theoretical m/z for %d peptides...", len(proformas))
     all_mz = ms2pip_compute_theoretical_mz(proformas, ion_types, frag_model, "monoisotopic")
 
-    # Batch compute features (single Rust call, Rayon-parallelized)
+    # Batch compute features
     logger.debug("Computing features for %d peptides...", len(proformas))
     all_features = ms2pip_compute_features(proformas)
 
@@ -115,41 +115,24 @@ def _predict_batch_internal(
     return results
 
 
-def _correlate_internal(
+def _validate_and_extract_targets(
     psm_spectrum_annotations: list[MatchedSpectrum],
     model: str,
-    model_dir: str | Path | None = None,
-    vector_file: bool = False,
-    annotations_only: bool = False,
     processes: int | None = None,
-) -> list[ProcessingResult]:
+) -> tuple[
+    list[MatchedSpectrum], list[ProcessingResult], list[dict], list[str], list[int]
+]:
     """
-    Core correlation logic: extract targets, compute features/predictions, assemble results.
+    Filter valid PSMs, extract observed targets, and prepare proformas/num_ions.
 
-    Parameters
-    ----------
-    psm_spectrum_annotations
-        List of (psm_index, psm, preprocessed_spectrum, peak_annotations) tuples.
-        Annotations are per-peak lists of ``(series, position, charge)`` tuples.
-    model
-        Name of prediction model.
-    model_dir
-        Directory for XGBoost model files.
-    vector_file
-        If True, return feature vectors instead of predictions (for training).
-    annotations_only
-        If True, return only m/z and observed intensities (no predictions).
-
+    Returns ``(valid_matches, skipped_results, all_targets, proformas, num_ions)``.
     """
-    if not annotations_only and not vector_file:
-        model_dir = validate_model(model, model_dir)
     ion_types = [it.lower() for it in MODELS[model]["ion_types"]]
-    frag_model = MODELS[model]["fragmentation"]
 
     _set_rayon_threads(processes)
 
     if not psm_spectrum_annotations:
-        return []
+        return [], [], [], [], []
 
     # Validate and filter
     psms_for_validation = PSMList(psm_list=[m.psm for m in psm_spectrum_annotations])
@@ -162,10 +145,7 @@ def _correlate_internal(
         for i, m in enumerate(psm_spectrum_annotations) if i not in valid_index_set
     ]
 
-    if not valid_matches:
-        return skipped_results
-
-    # Step 1: Extract targets from pre-computed annotations
+    # Extract targets from pre-computed annotations
     all_targets = []
     for m in valid_matches:
         if not m.psm.peptidoform.precursor_charge:
@@ -177,85 +157,113 @@ def _correlate_internal(
         )
         all_targets.append(targets)
 
-    proformas = [
-        proforma_to_mass_shift(m.psm.peptidoform) for m in valid_matches
-    ]
-    num_ions = [
-        len(m.psm.peptidoform.parsed_sequence) - 1 for m in valid_matches
-    ]
+    proformas = [proforma_to_mass_shift(m.psm.peptidoform) for m in valid_matches]
+    num_ions = [len(m.psm.peptidoform.parsed_sequence) - 1 for m in valid_matches]
 
-    # Step 2: Compute features (needed for training and prediction, not annotation-only)
-    all_features = None
-    if not annotations_only:
-        logger.debug("Computing features for %d peptides...", len(proformas))
-        all_features = ms2pip_compute_features(proformas)
+    return valid_matches, skipped_results, all_targets, proformas, num_ions
 
-    # Step 3: Compute theoretical m/z (needed for annotation and prediction, not training)
-    all_mz = None
-    if not vector_file:
-        logger.debug("Computing theoretical m/z for %d peptides...", len(proformas))
-        all_mz = ms2pip_compute_theoretical_mz(proformas, ion_types, frag_model, "monoisotopic")
 
-    # Step 4: Assemble results based on mode
-    results: list[ProcessingResult] = []
+def _predict_with_observed(
+    psm_spectrum_annotations: list[MatchedSpectrum],
+    model: str,
+    model_dir: str | Path | None = None,
+    processes: int | None = None,
+) -> list[ProcessingResult]:
+    """Compute features, m/z, XGBoost predictions, and observed targets for matched spectra."""
+    model_dir = validate_model(model, model_dir)
+    ion_types = [it.lower() for it in MODELS[model]["ion_types"]]
+    frag_model = MODELS[model]["fragmentation"]
 
-    if vector_file:
-        # Training mode: return feature vectors + observed targets
-        assert all_features is not None
-        for i, m in enumerate(valid_matches):
-            results.append(
-                ProcessingResult(
-                    psm_index=m.psm_index,
-                    psm=m.psm,
-                    theoretical_mz=None,
-                    predicted_intensity=None,
-                    observed_intensity=all_targets[i],
-                    correlation=None,
-                    feature_vectors=all_features[i],
-                )
-            )
+    valid_matches, skipped_results, all_targets, proformas, num_ions = (
+        _validate_and_extract_targets(psm_spectrum_annotations, model, processes)
+    )
+    if not valid_matches:
+        return skipped_results
 
-    elif annotations_only:
-        # Annotation mode: return m/z + observed targets
-        assert all_mz is not None
-        for i, m in enumerate(valid_matches):
-            mz = {k: np.array(v, dtype=np.float32) for k, v in all_mz[i].items()}
-            results.append(
-                ProcessingResult(
-                    psm_index=m.psm_index,
-                    psm=m.psm,
-                    theoretical_mz=mz,
-                    predicted_intensity=None,
-                    observed_intensity=all_targets[i],
-                    correlation=None,
-                    feature_vectors=None,
-                )
-            )
+    logger.debug("Computing features for %d peptides...", len(proformas))
+    all_features = ms2pip_compute_features(proformas)
 
-    else:
-        # Prediction mode: compute XGBoost predictions
-        assert all_features is not None and all_mz is not None
-        logger.debug("Predicting intensities with XGBoost...")
-        predictions = predict_intensities(
-            np.concatenate([f.reshape(-1, NUM_FEATURES) for f in all_features]),
-            num_ions,
-            MODELS[model],
-            model_dir,
-            processes=processes,
+    logger.debug("Computing theoretical m/z for %d peptides...", len(proformas))
+    all_mz = ms2pip_compute_theoretical_mz(proformas, ion_types, frag_model, "monoisotopic")
+
+    logger.debug("Predicting intensities with XGBoost...")
+    predictions = predict_intensities(
+        np.concatenate([f.reshape(-1, NUM_FEATURES) for f in all_features]),
+        num_ions,
+        MODELS[model],
+        model_dir,
+        processes=processes,
+    )
+
+    results = [
+        ProcessingResult(
+            psm_index=m.psm_index,
+            psm=m.psm,
+            theoretical_mz={k: np.array(v, dtype=np.float32) for k, v in all_mz[i].items()},
+            predicted_intensity=predictions[i],
+            observed_intensity=all_targets[i],
         )
+        for i, m in enumerate(valid_matches)
+    ]
+    results.extend(skipped_results)
+    return results
 
-        for i, m in enumerate(valid_matches):
-            mz = {k: np.array(v, dtype=np.float32) for k, v in all_mz[i].items()}
-            results.append(
-                ProcessingResult(
-                    psm_index=m.psm_index,
-                    psm=m.psm,
-                    theoretical_mz=mz,
-                    predicted_intensity=predictions[i],
-                    observed_intensity=all_targets[i],
-                )
-            )
 
+def _extract_observations(
+    psm_spectrum_annotations: list[MatchedSpectrum],
+    model: str,
+    processes: int | None = None,
+) -> list[ProcessingResult]:
+    """Compute theoretical m/z and extract observed targets (no predictions)."""
+    ion_types = [it.lower() for it in MODELS[model]["ion_types"]]
+    frag_model = MODELS[model]["fragmentation"]
+
+    valid_matches, skipped_results, all_targets, proformas, _ = (
+        _validate_and_extract_targets(psm_spectrum_annotations, model, processes)
+    )
+    if not valid_matches:
+        return skipped_results
+
+    logger.debug("Computing theoretical m/z for %d peptides...", len(proformas))
+    all_mz = ms2pip_compute_theoretical_mz(proformas, ion_types, frag_model, "monoisotopic")
+
+    results = [
+        ProcessingResult(
+            psm_index=m.psm_index,
+            psm=m.psm,
+            theoretical_mz={k: np.array(v, dtype=np.float32) for k, v in all_mz[i].items()},
+            observed_intensity=all_targets[i],
+        )
+        for i, m in enumerate(valid_matches)
+    ]
+    results.extend(skipped_results)
+    return results
+
+
+def _extract_training_data(
+    psm_spectrum_annotations: list[MatchedSpectrum],
+    model: str,
+    processes: int | None = None,
+) -> list[ProcessingResult]:
+    """Compute features and extract observed targets for model training (no m/z or predictions)."""
+    valid_matches, skipped_results, all_targets, proformas, _ = (
+        _validate_and_extract_targets(psm_spectrum_annotations, model, processes)
+    )
+    if not valid_matches:
+        return skipped_results
+
+    logger.debug("Computing features for %d peptides...", len(proformas))
+    all_features = ms2pip_compute_features(proformas)
+
+    results = [
+        ProcessingResult(
+            psm_index=m.psm_index,
+            psm=m.psm,
+            observed_intensity=all_targets[i],
+            feature_vectors=all_features[i],
+        )
+        for i, m in enumerate(valid_matches)
+    ]
     results.extend(skipped_results)
     return results
 
@@ -547,7 +555,7 @@ def correlate(
     )
 
     logger.info("Processing spectra and peptides...")
-    results = _correlate_internal(matched, model, model_dir, processes=processes)
+    results = _predict_with_observed(matched, model, model_dir, processes=processes)
 
     if compute_correlations:
         logger.info("Computing correlations")
@@ -661,13 +669,7 @@ def get_training_data(
         psm_list, spectrum_file, spectrum_id_pattern, model, ms2_tolerance, ms2_tolerance_mode
     )
 
-    results = _correlate_internal(
-        matched,
-        model,
-        model_dir=None,
-        vector_file=True,
-        processes=processes,
-    )
+    results = _extract_training_data(matched, model, processes=processes)
 
     logger.info("Assembling training data in DataFrame...")
     return _assemble_training_data(results, model)
@@ -722,13 +724,7 @@ def annotate_spectra(
         psm_list, spectrum_file, spectrum_id_pattern, model, ms2_tolerance, ms2_tolerance_mode
     )
 
-    return _correlate_internal(
-        matched,
-        model,
-        model_dir=None,
-        annotations_only=True,
-        processes=processes,
-    )
+    return _extract_observations(matched, model, processes=processes)
 
 
 def download_models(models: list[str] | None = None, model_dir: str | Path | None = None):

--- a/ms2pip/core.py
+++ b/ms2pip/core.py
@@ -12,6 +12,7 @@ import pandas as pd
 from ms2rescore_rs import (
     ms2pip_compute_features,  # type: ignore[ty:unresolved-import]
     ms2pip_compute_theoretical_mz,  # type: ignore[ty:unresolved-import]
+    ms2pip_extract_targets,  # type: ignore[ty:unresolved-import]
 )
 from psm_utils import PSM, Peptidoform, PSMList
 from rich.progress import track
@@ -22,7 +23,6 @@ from ms2pip._spectrum_processing import (
     annotate_spectrum,
     proforma_to_mass_shift,
     resolve_spectra,
-    targets_from_annotations,
 )
 from ms2pip._utils.psm_input import filter_valid_psms, read_psms
 from ms2pip._utils.xgb_models import load_xgb_models, predict_intensities, validate_model
@@ -109,7 +109,7 @@ def _predict_batch_internal(
         results[i] = ProcessingResult(
             psm_index=i,
             psm=psm_list[i],
-            theoretical_mz={k: np.array(v, dtype=np.float32) for k, v in all_mz[j].items()},
+            theoretical_mz=all_mz[j],
             predicted_intensity=predictions[j],
         )
     return results
@@ -145,17 +145,18 @@ def _validate_and_extract_targets(
         for i, m in enumerate(psm_spectrum_annotations) if i not in valid_index_set
     ]
 
-    # Extract targets from pre-computed annotations
-    all_targets = []
+    # Fill in missing precursor charges from spectra
     for m in valid_matches:
         if not m.psm.peptidoform.precursor_charge:
             m.psm.peptidoform.precursor_charge = m.spectrum.precursor_charge  # type: ignore[ty:invalid-assignment]
 
-        seq_len = len(m.psm.peptidoform.parsed_sequence)
-        targets = targets_from_annotations(
-            m.peak_annotations, m.spectrum.intensity.astype(np.float32), ion_types, seq_len
-        )
-        all_targets.append(targets)
+    # Extract targets from annotations (single batch Rust call)
+    all_targets = ms2pip_extract_targets(
+        annotated_spectra=[m.annotated_spectrum for m in valid_matches],
+        intensities=[m.spectrum.intensity.astype(np.float32) for m in valid_matches],
+        ion_types=ion_types,
+        seq_lens=[len(m.psm.peptidoform.parsed_sequence) for m in valid_matches],
+    )
 
     proformas = [proforma_to_mass_shift(m.psm.peptidoform) for m in valid_matches]
     num_ions = [len(m.psm.peptidoform.parsed_sequence) - 1 for m in valid_matches]
@@ -199,7 +200,7 @@ def _predict_with_observed(
         ProcessingResult(
             psm_index=m.psm_index,
             psm=m.psm,
-            theoretical_mz={k: np.array(v, dtype=np.float32) for k, v in all_mz[i].items()},
+            theoretical_mz=all_mz[i],
             predicted_intensity=predictions[i],
             observed_intensity=all_targets[i],
         )
@@ -231,7 +232,7 @@ def _extract_observations(
         ProcessingResult(
             psm_index=m.psm_index,
             psm=m.psm,
-            theoretical_mz={k: np.array(v, dtype=np.float32) for k, v in all_mz[i].items()},
+            theoretical_mz=all_mz[i],
             observed_intensity=all_targets[i],
         )
         for i, m in enumerate(valid_matches)
@@ -609,9 +610,12 @@ def correlate_single(
     annotated = annotate_spectrum(preprocessed, psm, model, ms2_tolerance, ms2_tolerance_mode)
     ion_types = [it.lower() for it in MODELS[model]["ion_types"]]
     seq_len = len(observed_spectrum.peptidoform.parsed_sequence)
-    observed_intensity = targets_from_annotations(
-        annotated, preprocessed.intensity.astype(np.float32), ion_types, seq_len
-    )
+    observed_intensity = ms2pip_extract_targets(
+        annotated_spectra=[annotated],
+        intensities=[preprocessed.intensity.astype(np.float32)],
+        ion_types=ion_types,
+        seq_lens=[seq_len],
+    )[0]
 
     result = predict_single(observed_spectrum.peptidoform, model=model)
     result.observed_intensity = observed_intensity

--- a/ms2pip/core.py
+++ b/ms2pip/core.py
@@ -452,7 +452,7 @@ def predict_library(
         search_space = ProteomeSearchSpace.from_any(config)
         search_space.fasta_file = Path(fasta_file)
     elif fasta_file and not config:
-        search_space = ProteomeSearchSpace(fasta_file=fasta_file)
+        search_space = ProteomeSearchSpace(fasta_file=Path(fasta_file))
     elif not fasta_file and config:
         search_space = ProteomeSearchSpace.from_any(config)
     else:

--- a/ms2pip/result.py
+++ b/ms2pip/result.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import csv
 from logging import getLogger
 from pathlib import Path
-from typing import Any
-
 import numpy as np
 from psm_utils import PSM
 from pydantic import BaseModel, ConfigDict
@@ -23,7 +21,26 @@ logger = getLogger(__name__)
 
 
 class ProcessingResult(BaseModel):
-    """Result of processing a single PSM."""
+    """
+    Result of processing a single PSM.
+
+    Parameters
+    ----------
+    psm_index
+        Index of the PSM in the input list.
+    psm
+        The PSM object.
+    theoretical_mz
+        Dict mapping ion type to theoretical m/z array.
+    predicted_intensity
+        Dict mapping ion type to predicted intensity array.
+    observed_intensity
+        Dict mapping ion type to observed intensity array.
+    correlation
+        Pearson correlation between predicted and observed intensities.
+    feature_vectors
+        Feature vectors for model training.
+    """
 
     psm_index: int
     psm: PSM
@@ -33,10 +50,6 @@ class ProcessingResult(BaseModel):
     correlation: float | None = None
     feature_vectors: np.ndarray | None = None
     model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    def __init__(__pydantic_self__, **data: Any) -> None:
-        """Result of processing a single PSM."""
-        super().__init__(**data)
 
     def as_spectra(self) -> tuple[PredictedSpectrum | None, ObservedSpectrum | None]:
         """Convert result to predicted and observed spectra."""
@@ -52,8 +65,7 @@ class ProcessingResult(BaseModel):
         peak_order = np.argsort(mz)
 
         if self.predicted_intensity:
-            pred_int = np.concatenate([i for i in self.predicted_intensity.values()])
-            pred_int = (2**pred_int) - 0.001  # Unlog intensities
+            pred_int = np.concatenate(list(self.predicted_intensity.values()))
             predicted = PredictedSpectrum(
                 mz=mz[peak_order],
                 intensity=pred_int[peak_order],
@@ -61,12 +73,12 @@ class ProcessingResult(BaseModel):
                 peptidoform=self.psm.peptidoform if self.psm else None,
                 precursor_charge=self.psm.peptidoform.precursor_charge if self.psm else None,
             )
+            predicted.inverse_log2_transform()
         else:
             predicted = None
 
         if self.observed_intensity:
-            obs_int = np.concatenate([i for i in self.observed_intensity.values()])
-            obs_int = (2**obs_int) - 0.001  # Unlog intensities
+            obs_int = np.concatenate(list(self.observed_intensity.values()))
             observed = ObservedSpectrum(
                 mz=mz[peak_order],
                 intensity=obs_int[peak_order],
@@ -74,6 +86,7 @@ class ProcessingResult(BaseModel):
                 peptidoform=self.psm.peptidoform if self.psm else None,
                 precursor_charge=self.psm.peptidoform.precursor_charge if self.psm else None,
             )
+            observed.inverse_log2_transform()
         else:
             observed = None
 
@@ -113,6 +126,7 @@ class ProcessingResult(BaseModel):
 
 def calculate_correlations(results: list[ProcessingResult]) -> None:
     """Calculate and add Pearson correlations to list of results."""
+    # TODO: Consider nan values? https://github.com/CompOmics/ms2pip/pull/214/changes#diff-5f77421a48cf8f17c5b83ed031897ce8076e2f52c0028aa6f4294a34ba3b3305R115-R123
     for result in results:
         if result.predicted_intensity is None or result.observed_intensity is None:
             continue

--- a/ms2pip/search_space.py
+++ b/ms2pip/search_space.py
@@ -80,12 +80,10 @@ from functools import partial
 from itertools import chain, combinations, product
 from logging import getLogger
 from pathlib import Path
-from typing import Any
-
 import numpy as np
 import pyteomics.fasta
 from psm_utils import PSM, PSMList
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, PrivateAttr, field_validator, model_validator
 from pyteomics.parser import icleave
 from rich.progress import track
 
@@ -93,7 +91,27 @@ logger = getLogger(__name__)
 
 
 class ModificationConfig(BaseModel):
-    """Configuration for a single modification in the search space."""
+    """
+    Configuration for a single modification in the search space.
+
+    Parameters
+    ----------
+    label
+        Label of the modification. This can be any valid ProForma 2.0 label.
+    amino_acid
+        Amino acid target of the modification. :py:obj:`None` if the modification is not
+        specific to an amino acid. Default is None.
+    peptide_n_term
+        Whether the modification occurs only on the peptide N-terminus. Default is False.
+    protein_n_term
+        Whether the modification occurs only on the protein N-terminus. Default is False.
+    peptide_c_term
+        Whether the modification occurs only on the peptide C-terminus. Default is False.
+    protein_c_term
+        Whether the modification occurs only on the protein C-terminus. Default is False.
+    fixed
+        Whether the modification is fixed. Default is False.
+    """
 
     label: str
     amino_acid: str | None = None
@@ -102,31 +120,6 @@ class ModificationConfig(BaseModel):
     peptide_c_term: bool | None = False
     protein_c_term: bool | None = False
     fixed: bool | None = False
-
-    def __init__(self, **data: Any):
-        """
-        Configuration for a single modification in the search space.
-
-        Parameters
-        ----------
-        label
-            Label of the modification. This can be any valid ProForma 2.0 label.
-        amino_acid
-            Amino acid target of the modification. :py:obj:`None` if the modification is not
-            specific to an amino acid. Default is None.
-        peptide_n_term
-            Whether the modification occurs only on the peptide N-terminus. Default is False.
-        protein_n_term
-            Whether the modification occurs only on the protein N-terminus. Default is False.
-        peptide_c_term
-            Whether the modification occurs only on the peptide C-terminus. Default is False.
-        protein_c_term
-            Whether the modification occurs only on the protein C-terminus. Default is False.
-        fixed
-            Whether the modification is fixed. Default is False.
-
-        """
-        super().__init__(**data)
 
     @model_validator(mode="after")
     def _modification_must_have_target(self):
@@ -156,7 +149,37 @@ DEFAULT_MODIFICATIONS = [
 
 
 class ProteomeSearchSpace(BaseModel):
-    """Search space for in silico spectral library generation."""
+    """
+    Search space for in silico spectral library generation.
+
+    Parameters
+    ----------
+    fasta_file
+        Path to FASTA file with protein sequences.
+    min_length
+        Minimum peptide length. Default is 8.
+    max_length
+        Maximum peptide length. Default is 30.
+    min_precursor_mz
+        Minimum precursor m/z for peptides. Default is 0.
+    max_precursor_mz
+        Maximum precursor m/z for peptides. Default is np.inf.
+    cleavage_rule
+        Cleavage rule for peptide digestion. Default is "trypsin".
+    missed_cleavages
+        Maximum number of missed cleavages. Default is 2.
+    semi_specific
+        Allow semi-specific cleavage. Default is False.
+    add_decoys
+        Add decoy sequences to search space. Default is False.
+    modifications
+        List of modifications to consider. Default is oxidation of M and
+        carbamidomethylation of C.
+    max_variable_modifications
+        Maximum number of variable modifications per peptide. Default is 3.
+    charges
+        List of charges to consider. Default is [2, 3].
+    """
 
     fasta_file: Path
     min_length: int = 8
@@ -171,42 +194,7 @@ class ProteomeSearchSpace(BaseModel):
     max_variable_modifications: int = 3
     charges: list[int] = [2, 3]
 
-    def __init__(self, **data: Any):
-        """
-        Search space for in silico spectral library generation.
-
-        Parameters
-        ----------
-        fasta_file
-            Path to FASTA file with protein sequences.
-        min_length
-            Minimum peptide length. Default is 8.
-        max_length
-            Maximum peptide length. Default is 30.
-        min_precursor_mz
-            Minimum precursor m/z for peptides. Default is 0.
-        max_precursor_mz
-            Maximum precursor m/z for peptides. Default is np.inf.
-        cleavage_rule
-            Cleavage rule for peptide digestion. Default is "trypsin".
-        missed_cleavages
-            Maximum number of missed cleavages. Default is 2.
-        semi_specific
-            Allow semi-specific cleavage. Default is False.
-        add_decoys
-            Add decoy sequences to search space. Default is False.
-        modifications
-            List of modifications to consider. Default is oxidation of M and carbamidomethylation
-            of C.
-        max_variable_modifications
-            Maximum number of variable modifications per peptide. Default is 3.
-        charges
-            List of charges to consider. Default is [2, 3].
-
-        """
-
-        super().__init__(**data)
-        self._peptidoform_spaces: list[_PeptidoformSearchSpace] = []
+    _peptidoform_spaces: list[_PeptidoformSearchSpace] = PrivateAttr(default_factory=list)
 
     @field_validator("modifications")
     @classmethod
@@ -394,7 +382,24 @@ class ProteomeSearchSpace(BaseModel):
 
 
 class _PeptidoformSearchSpace(BaseModel):
-    """Search space for a given amino acid sequence."""
+    """
+    Search space for a given amino acid sequence.
+
+    Parameters
+    ----------
+    sequence
+        Amino acid sequence of the peptidoform.
+    proteins
+        List of protein IDs containing the peptidoform.
+    is_n_term
+        Whether the peptidoform is an N-terminal peptide. Default is None.
+    is_c_term
+        Whether the peptidoform is a C-terminal peptide. Default is None.
+    modification_options
+        List of dictionaries with modification positions and configurations. Default is [].
+    charge_options
+        List of charge states to consider. Default is [].
+    """
 
     sequence: str
     proteins: list[str]
@@ -402,28 +407,6 @@ class _PeptidoformSearchSpace(BaseModel):
     is_c_term: bool | None = None
     modification_options: list[dict[int, ModificationConfig]] = []
     charge_options: list[int] = []
-
-    def __init__(self, **data: Any):
-        """
-        Search space for a given amino acid sequence.
-
-        Parameters
-        ----------
-        sequence
-            Amino acid sequence of the peptidoform.
-        proteins
-            List of protein IDs containing the peptidoform.
-        is_n_term
-            Whether the peptidoform is an N-terminal peptide. Default is None.
-        is_c_term
-            Whether the peptidoform is a C-terminal peptide. Default is None.
-        modification_options
-            List of dictionaries with modification positions and configurations. Default is [].
-        charge_options
-            List of charge states to consider. Default is [].
-
-        """
-        super().__init__(**data)
 
     def __len__(self):
         return len(self.modification_options) * len(self.charge_options)

--- a/ms2pip/spectrum.py
+++ b/ms2pip/spectrum.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any
-
 import numpy as np
 from psm_utils import Peptidoform
 from pydantic import model_validator, field_validator, ConfigDict, BaseModel
@@ -18,7 +16,32 @@ except ImportError:
 
 
 class Spectrum(BaseModel):
-    """MS2 spectrum."""
+    """
+    MS2 spectrum.
+
+    Parameters
+    ----------
+    mz
+        Array of m/z values.
+    intensity
+        Array of intensity values.
+    annotations
+        Array of peak annotations.
+    identifier
+        Spectrum identifier.
+    peptidoform
+        Peptidoform.
+    precursor_mz
+        Precursor m/z.
+    precursor_charge
+        Precursor charge.
+    retention_time
+        Retention time.
+    mass_tolerance
+        Mass tolerance for spectrum annotation.
+    mass_tolerance_unit
+        Unit of mass tolerance for spectrum annotation.
+    """
 
     mz: np.ndarray
     intensity: np.ndarray
@@ -32,36 +55,6 @@ class Spectrum(BaseModel):
     mass_tolerance_unit: str | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    def __init__(__pydantic_self__, **data: Any) -> None:
-        """
-        MS2 spectrum.
-
-        Parameters
-        ----------
-        mz
-            Array of m/z values.
-        intensity
-            Array of intensity values.
-        annotations
-            Array of peak annotations.
-        identifier
-            Spectrum identifier.
-        peptidoform
-            Peptidoform.
-        precursor_mz
-            Precursor m/z.
-        precursor_charge
-            Precursor charge.
-        retention_time
-            Retention time.
-        mass_tolerance
-            Mass tolerance for spectrum annotation.
-        mass_tolerance_unit
-            Unit of mass tolerance for spectrum annotation.
-
-        """
-        super().__init__(**data)
 
     def __repr__(self) -> str:
         return "{}.{}({})".format(
@@ -122,8 +115,12 @@ class Spectrum(BaseModel):
         self.intensity = self.intensity / self.tic
 
     def log2_transform(self) -> None:
-        """Log2-tranform spectrum."""
+        """Log2-transform spectrum."""
         self.intensity = np.log2(self.intensity + 0.001)
+
+    def inverse_log2_transform(self) -> None:
+        """Undo log2 transformation of intensities (inverse of :meth:`log2_transform`)."""
+        self.intensity = (2**self.intensity) - 0.001
 
     def clip_intensity(self, min_intensity=0.0) -> None:
         """Clip intensity values."""

--- a/ms2pip/spectrum_output.py
+++ b/ms2pip/spectrum_output.py
@@ -422,7 +422,7 @@ class Spectronaut(_Writer):
         """Yield fragment information for a processing result."""
         # Normalize intensities
         intensities = {
-            ion_type: _unlogarithmize(intensities)
+            ion_type: (2**intensities) - 0.001
             for ion_type, intensities in result.predicted_intensity.items()  # type: ignore[ty:unresolved-attribute]
         }
         max_intensity = max(itertools.chain(*intensities.values()))
@@ -779,11 +779,6 @@ SUPPORTED_FORMATS = {
 def _peptidoform_str_without_charge(peptidoform: Peptidoform) -> str:
     """Get peptidoform string without charge."""
     return re.sub(r"\/\d+$", "", str(peptidoform))
-
-
-def _unlogarithmize(intensities: np.array) -> np.array:  # type: ignore[ty:invalid-type-form]
-    """Undo logarithmic transformation of intensities."""
-    return (2**intensities) - 0.001
 
 
 def _basepeak_normalize(intensities: np.array, basepeak: float | None = None) -> np.array:  # type: ignore[ty:invalid-type-form]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pydantic>=2",
     "werkzeug>=2",
     "psm_utils>=1.5",
-    "ms2rescore-rs>=0.5.0a1,<2",
+    "ms2rescore-rs>=0.5.0a3,<2",
 ]
 [project.optional-dependencies]
 plotting = ["matplotlib>=3.0", "spectrum-utils>=0.4"]

--- a/tests/test_spectrum_processing.py
+++ b/tests/test_spectrum_processing.py
@@ -1,24 +1,43 @@
 import numpy as np
+from ms2rescore_rs import AnnotatedMS2Spectrum, FragmentAnnotation, Precursor
 from psm_utils import PSM, Peptidoform
 
 from ms2pip._spectrum_processing import (
     annotate_spectrum,
     proforma_to_mass_shift,
-    targets_from_annotations,
 )
+from ms2rescore_rs import ms2pip_extract_targets
 
 
-def test_targets_from_annotations_basic():
+def _make_annotated_spectrum(peak_annotations, intensity, seq_len=4):
+    """Helper to build an AnnotatedMS2Spectrum for testing ms2pip_extract_targets."""
+    mz = list(range(len(intensity)))  # dummy m/z values
+    return AnnotatedMS2Spectrum(
+        identifier="test",
+        mz=mz,
+        intensity=list(intensity),
+        precursor=Precursor(mz=0.0, charge=2, rt=0.0),
+        peak_annotations=peak_annotations,
+    )
+
+
+def test_extract_targets_basic():
     """Test basic target extraction from annotations."""
-    # 4-residue peptide → 3 cleavage sites
+    # 4-residue peptide -> 3 cleavage sites
     peak_annotations = [
-        [("b", 1, 1)],  # peak 0 matches b1
-        [],  # peak 1 unmatched
-        [("y", 2, 1)],  # peak 2 matches y2
+        [FragmentAnnotation(series="b", position=1, charge=1)],
+        [],
+        [FragmentAnnotation(series="y", position=2, charge=1)],
     ]
     intensity = np.array([5.0, 3.0, 8.0], dtype=np.float32)
+    annotated = _make_annotated_spectrum(peak_annotations, intensity)
 
-    targets = targets_from_annotations(peak_annotations, intensity, ["b", "y"], seq_len=4)
+    targets = ms2pip_extract_targets(
+        annotated_spectra=[annotated],
+        intensities=[intensity],
+        ion_types=["b", "y"],
+        seq_lens=[4],
+    )[0]
 
     floor = np.float32(np.log2(0.001))
     assert targets["b"][0] == 5.0  # b1 at position 0
@@ -29,65 +48,67 @@ def test_targets_from_annotations_basic():
     assert targets["y"][2] == floor  # y3 unmatched
 
 
-def test_targets_from_annotations_charge2():
+def test_extract_targets_charge2():
     """Test that charge-2 annotations map to b2/y2 ion types."""
     peak_annotations = [
-        [("b", 1, 2)],  # charge 2 → maps to "b2"
+        [FragmentAnnotation(series="b", position=1, charge=2)],
     ]
     intensity = np.array([10.0], dtype=np.float32)
+    annotated = _make_annotated_spectrum(peak_annotations, intensity)
 
-    targets = targets_from_annotations(
-        peak_annotations, intensity, ["b", "y", "b2", "y2"], seq_len=4
-    )
+    targets = ms2pip_extract_targets(
+        annotated_spectra=[annotated],
+        intensities=[intensity],
+        ion_types=["b", "y", "b2", "y2"],
+        seq_lens=[4],
+    )[0]
 
     assert targets["b2"][0] == 10.0
     floor = np.float32(np.log2(0.001))
     assert targets["b"][0] == floor  # charge-1 b is not matched
 
 
-def test_targets_from_annotations_highest_intensity():
+def test_extract_targets_highest_intensity():
     """Test that the highest intensity is kept when multiple peaks match."""
     peak_annotations = [
-        [("b", 1, 1)],  # peak 0: b1 with intensity 3.0
-        [("b", 1, 1)],  # peak 1: b1 with intensity 7.0
+        [FragmentAnnotation(series="b", position=1, charge=1)],
+        [FragmentAnnotation(series="b", position=1, charge=1)],
     ]
     intensity = np.array([3.0, 7.0], dtype=np.float32)
+    annotated = _make_annotated_spectrum(peak_annotations, intensity)
 
-    targets = targets_from_annotations(peak_annotations, intensity, ["b", "y"], seq_len=4)
+    targets = ms2pip_extract_targets(
+        annotated_spectra=[annotated],
+        intensities=[intensity],
+        ion_types=["b", "y"],
+        seq_lens=[4],
+    )[0]
 
     assert targets["b"][0] == 7.0  # highest wins
 
 
-def test_targets_from_annotations_ignores_unknown_ion_types():
+def test_extract_targets_ignores_unknown_ion_types():
     """Test that annotations for ion types not in the target list are ignored."""
     peak_annotations = [
-        [("c", 1, 1)],  # c-ion not in requested types
+        [FragmentAnnotation(series="c", position=1, charge=1)],
     ]
     intensity = np.array([10.0], dtype=np.float32)
+    annotated = _make_annotated_spectrum(peak_annotations, intensity)
 
-    targets = targets_from_annotations(peak_annotations, intensity, ["b", "y"], seq_len=4)
+    targets = ms2pip_extract_targets(
+        annotated_spectra=[annotated],
+        intensities=[intensity],
+        ion_types=["b", "y"],
+        seq_lens=[4],
+    )[0]
 
     floor = np.float32(np.log2(0.001))
     assert all(v == floor for v in targets["b"])
     assert all(v == floor for v in targets["y"])
 
 
-def test_targets_from_annotations_fragment_annotation_objects():
-    """Test that FragmentAnnotation objects (not tuples) also work."""
-    from ms2rescore_rs import FragmentAnnotation
-
-    peak_annotations = [
-        [FragmentAnnotation(series="b", position=1, charge=1)],
-    ]
-    intensity = np.array([5.0], dtype=np.float32)
-
-    targets = targets_from_annotations(peak_annotations, intensity, ["b", "y"], seq_len=4)
-
-    assert targets["b"][0] == 5.0
-
-
 def test_annotate_spectrum():
-    """Test that annotate_spectrum returns annotations for matching peaks."""
+    """Test that annotate_spectrum returns an AnnotatedMS2Spectrum."""
     spectrum = __import__("ms2pip.spectrum", fromlist=["ObservedSpectrum"]).ObservedSpectrum(
         mz=np.array([72.044, 175.054, 290.081], dtype=np.float32),
         intensity=np.array([100.0, 200.0, 300.0], dtype=np.float32),
@@ -98,12 +119,13 @@ def test_annotate_spectrum():
     )
     psm = PSM(peptidoform=Peptidoform("ACDE/2"), spectrum_id="test")
 
-    annotations = annotate_spectrum(spectrum, psm, "HCD", 0.02, "Da")
+    result = annotate_spectrum(spectrum, psm, "HCD", 0.02, "Da")
 
-    # Should return one list of annotations per peak
-    assert len(annotations) == 3
-    # At least some peaks should be annotated (b1 at ~72.044, b2 at ~175.054)
-    annotated_peaks = [i for i, anns in enumerate(annotations) if len(anns) > 0]
+    assert isinstance(result, AnnotatedMS2Spectrum)
+    # Should have one annotation list per peak
+    assert len(result.peak_annotations) == 3
+    # At least some peaks should be annotated
+    annotated_peaks = [i for i, anns in enumerate(result.peak_annotations) if len(anns) > 0]
     assert len(annotated_peaks) > 0
 
 


### PR DESCRIPTION
## Summary

This PR simplifies the Python/Rust boundary for annotation and target extraction, and keeps the correlate flow working with both raw and pre-annotated preloaded spectra. Final performance improved substantially after the Rust-side follow-up.

## Changelog

### Added
- Support for using Rust `ms2pip_extract_targets(...)` in the correlate pipeline.
- Support for carrying `AnnotatedMS2Spectrum` objects directly through the preloaded-spectrum path.

### Changed
- Updated MS²PIP to consume `ms2pip_compute_theoretical_mz(...)` results directly from Rust without wrapping them again in `np.array(...)`.
- Updated annotation calls so `annotate_ms2_spectra(...)` no longer receives `seq_lens`.
- Updated `annotate_spectrum(...)` to return `AnnotatedMS2Spectrum` instead of Python tuple-converted annotations.
- Updated `MatchedSpectrum` to store `annotated_spectrum` instead of `peak_annotations`.
- Updated `_validate_and_extract_targets(...)` to batch target extraction through a single Rust call.
- Updated `correlate_single(...)` to use Rust target extraction as well.
- Updated `tests/test_spectrum_processing.py` to validate Rust target extraction directly using `AnnotatedMS2Spectrum` / `FragmentAnnotation`.
- Bumped `ms2rescore-rs` dependency in `pyproject.toml` to `>=0.5.0a3,<2`.

### Removed
- Python-side `_annotations_to_tuples(...)` from the active annotation/target-extraction flow.
- Python-side `targets_from_annotations(...)` from the active correlate flow.
- Redundant Python-side conversion of annotation results back into tuple structures when pre-annotated spectra are already available.

### Fixed
- Restored / improved correlate performance after the initial API migration by following up on Rust-side bottlenecks (down from ~110 sec to ~75 sec for ~78k spectra).
