### PR TITLE
Fix pydantic validation on `Spectrum`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,35 +1,15 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
 version: 2
 
 build:
-  os: ubuntu-lts-latest
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
-  jobs:
-    post_checkout:
-      # Download and uncompress the binary
-      # https://git-lfs.github.com/
-      - wget https://github.com/git-lfs/git-lfs/releases/download/v3.1.4/git-lfs-linux-amd64-v3.1.4.tar.gz
-      - tar xvfz git-lfs-linux-amd64-v3.1.4.tar.gz
-      # Modify LFS config paths to point where git-lfs binary was downloaded
-      - git config filter.lfs.process "`pwd`/git-lfs filter-process"
-      - git config filter.lfs.smudge  "`pwd`/git-lfs smudge -- %f"
-      - git config filter.lfs.clean "`pwd`/git-lfs clean -- %f"
-      # Make LFS available in current repository
-      - ./git-lfs install
-      # Download content from remote
-      - ./git-lfs fetch
-      # Make local files to have the real content on them
-      - ./git-lfs checkout
-    post_install:
-      - rm -r ms2pip
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-
-sphinx:
-  builder: dirhtml
-  configuration: docs/source/conf.py
+    python: "3.13"
+  commands:
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
+    - uv sync --group docs
+    - cd docs/source && uv run python -m sphinx -T -b dirhtml . $READTHEDOCS_OUTPUT/html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `Spectrum` model: deprecated `model_validator`/`classmethod` combination, missing serializers for `np.ndarray` fields (broke `model_dump_json()`), and equality comparison crashing on array fields
+
 ## [4.2.0-beta.1] - 2026-06-19
 
 ### Added

--- a/ms2pip/spectrum.py
+++ b/ms2pip/spectrum.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import warnings
-from typing import Annotated
+from typing import Annotated, Any
 
 import numpy as np
 from psm_utils import Peptidoform
-from pydantic import BaseModel, BeforeValidator, ConfigDict, model_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, field_serializer, model_validator
 
 
 def _coerce_peptidoform(v):
@@ -70,14 +70,37 @@ class Spectrum(BaseModel):
         )
 
     @model_validator(mode="after")
-    @classmethod
-    def check_array_lengths(cls, data):
-        if len(data.mz) != len(data.intensity):
+    def check_array_lengths(self):
+        if len(self.mz) != len(self.intensity):
             raise ValueError("Array lengths do not match.")
-        if data.annotations is not None:
-            if len(data.annotations) != len(data.intensity):
+        if self.annotations is not None:
+            if len(self.annotations) != len(self.intensity):
                 raise ValueError("Array lengths do not match.")
-        return data
+        return self
+
+    @field_serializer("mz", "intensity", "annotations")
+    def _serialize_array(self, value: np.ndarray | None) -> list | None:
+        return value.tolist() if value is not None else None
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Spectrum):
+            return NotImplemented
+        return (
+            np.array_equal(self.mz, other.mz)
+            and np.array_equal(self.intensity, other.intensity)
+            and (
+                np.array_equal(self.annotations, other.annotations)
+                if self.annotations is not None and other.annotations is not None
+                else self.annotations is other.annotations
+            )
+            and self.identifier == other.identifier
+            and self.peptidoform == other.peptidoform
+            and self.precursor_mz == other.precursor_mz
+            and self.precursor_charge == other.precursor_charge
+            and self.retention_time == other.retention_time
+            and self.mass_tolerance == other.mass_tolerance
+            and self.mass_tolerance_unit == other.mass_tolerance_unit
+        )
 
     @property
     def tic(self):


### PR DESCRIPTION
`Spectrum` model: deprecated `model_validator`/`classmethod` combination, missing serializers for `np.ndarray` fields (broke `model_dump_json()`), and equality comparison crashing on array fields.

Also fix builds for readthedocs.
